### PR TITLE
Applying power plan error fix (multilanguage cmd output)

### DIFF
--- a/optimizerDuck/Domain/Optimizations/Categories/PowerManagement.cs
+++ b/optimizerDuck/Domain/Optimizations/Categories/PowerManagement.cs
@@ -127,7 +127,7 @@ public class PowerManagement : IOptimizationCategory
             var activeQuery = await ShellService.CMDAsync("powercfg /getactivescheme");
             var match = Regex.Match(
                 activeQuery.Stdout,
-                @"Power Scheme GUID:\s*([a-fA-F0-9\-]{36})",
+                @".*:\s*([a-fA-F0-9\-]{36})",
                 RegexOptions.IgnoreCase
             );
 


### PR DESCRIPTION
## Description

Before downloading custom power scheme you check the GUID of active PS. If your sys language set to English, you get "Power Scheme GUID:" text. I got my sys language set to Russian, so i get different output, why i got an error of getting current GUID. So i changed Regex.Match 2nd argument to skip all characters before char ':'.

## Type of Change

- [ ] 🐛 Bug fix (`fix:` - non-breaking change which fixes an issue)
