### PR TITLE
I18n/add pt br language

### DIFF
--- a/optimizerDuck/Resources/Languages/Translations.pt-BR.resx
+++ b/optimizerDuck/Resources/Languages/Translations.pt-BR.resx
@@ -146,10 +146,10 @@
     <value>{0} Threads</value>
   </data>
   <data name="Dashboard.SystemInfo.Storage.System" xml:space="preserve">
-    <value>SISTEMA</value>
+    <value>Sistema</value>
   </data>
   <data name="Dashboard.SystemInfo.Storage.Header" xml:space="preserve">
-    <value>Storage</value>
+    <value>Armazenamento</value>
   </data>
   <data name="Dashboard.SystemInfo.Ram.Used" xml:space="preserve">
     <value>{0} GB Usado</value>
@@ -947,860 +947,860 @@
     <value>Mostrar Extensões de Arquivos</value>
   </data>
   <data name="Customize.Preferences.ShowFileExtensions.Description" xml:space="preserve">
-    <value>Shows file extensions (e.g. .txt, .exe) in File Explorer.</value>
+    <value>Mostra as extensões de arquivos (ex.: .txt, .exe) no Explorer de arquivos.</value> 
   </data>
   <data name="Customize.Preferences.ShowFileExtensions.Recommendation.Reason" xml:space="preserve">
-    <value>Showing file extensions makes it easy to spot suspicious file types and prevents malware from hiding behind fake icons.</value>
+    <value>Mostrar extensões de arquivos facilita a identificação de tipos de arquivos suspeitos e impede que malware se esconda atrás de ícones falsos.</value>
   </data>
   <data name="Customize.Preferences.ShowHiddenFiles.Name" xml:space="preserve">
-    <value>Show Hidden Files</value>
+    <value>Mostrar Arquivos Ocultos</value>
   </data>
   <data name="Customize.Preferences.ShowHiddenFiles.Description" xml:space="preserve">
-    <value>Shows hidden files and folders in File Explorer.</value>
+    <value>Mostra arquivos e pastas ocultas no Explorer de arquivos.</value>
   </data>
   <data name="Customize.Preferences.ShowHiddenFiles.Recommendation.Reason" xml:space="preserve">
-    <value>Hidden files contain system and config data you may need to manage; showing them gives you full visibility of your system.</value>
+    <value>Arquivos ocultos contêm dados do sistema e configuração que você pode precisar gerenciar; mostrá-los dá a você visibilidade total do seu sistema.</value>
   </data>
   <data name="Customize.Preferences.ClipboardHistory.Name" xml:space="preserve">
-    <value>Clipboard History</value>
+    <value>Histórico do Clipboard</value>
   </data>
   <data name="Customize.Preferences.ClipboardHistory.Description" xml:space="preserve">
-    <value>Clipboard history for multiple copied items accessible with Win+V.</value>
+    <value>Histórico do clipboard para múltiplos itens copiados acessíveis com Win+V.</value>
   </data>
   <data name="Customize.Preferences.ClipboardHistory.Recommendation.Reason" xml:space="preserve">
-    <value>Clipboard history lets you recall multiple past copies with Win+V, speeding up repetitive copy-paste workflows.</value>
+    <value>Histórico do clipboard permite relembrar múltiplas cópias passadas com Win+V, acelerando fluxos de trabalho de cópia-colagem repetitivos.</value>
   </data>
   <data name="Customize.Preferences.WindowShake.Name" xml:space="preserve">
-    <value>Window Shake</value>
+    <value>Agitar Janela</value> 
   </data>
   <data name="Customize.Preferences.WindowShake.Description" xml:space="preserve">
-    <value>Shake a window to minimize all other open windows.</value>
+    <value>Agite uma janela para minimizar todas as outras janelas abertas.</value>
   </data>
   <data name="Customize.Preferences.ClassicContextMenu.Name" xml:space="preserve">
-    <value>Classic Context Menu</value>
+    <value>Menu Contextual Clássico</value>
   </data>
   <data name="Customize.Preferences.ClassicContextMenu.Description" xml:space="preserve">
-    <value>Windows 10-style context menu on Windows 11.</value>
+    <value>Menu contextual estilo Windows 10 no Windows 11.</value>
   </data>
   <data name="Customize.Preferences.ClassicContextMenu.Recommendation.Reason" xml:space="preserve">
-    <value>The classic menu shows all options at once without the extra click needed to expand Windows 11's condensed menu.</value>
+    <value>O menu clássico mostra todas as opções de uma vez sem o clique extra necessário para expandir o menu condensado do Windows 11.</value>
   </data>
   <data name="Customize.Preferences.ShowSecondsInSystemClock.Name" xml:space="preserve">
-    <value>Seconds in System Clock</value>
+    <value>Segundos no Relógio do Sistema</value>
   </data>
   <data name="Customize.Preferences.ShowSecondsInSystemClock.Description" xml:space="preserve">
-    <value>Displays seconds in the taskbar clock.</value>
+    <value>Exibe segundos no relógio da barra de tarefas.</value>
   </data>
   <data name="Customize.Gaming.Section.GameSettings" xml:space="preserve">
-    <value>Game Settings</value>
+    <value>Configurações de Jogo</value>
   </data>
   <data name="Customize.Gaming.Section.Input" xml:space="preserve">
-    <value>Input</value>
+    <value>Entrada</value>
   </data>
   <data name="Customize.Gaming.Section.Display" xml:space="preserve">
-    <value>Display</value>
+    <value>Exibição</value>
   </data>
   <data name="Customize.Gaming.GameMode.Name" xml:space="preserve">
-    <value>Game Mode</value>
+    <value>Modo de Jogo</value>
   </data>
   <data name="Customize.Gaming.GameMode.Description" xml:space="preserve">
-    <value>Windows Game Mode for gaming processes and Windows Update behavior.</value>
+    <value>Modo de jogo do Windows para processos de jogo e comportamento de atualização do Windows.</value>
   </data>
   <data name="Customize.Gaming.GameMode.Recommendation.Reason" xml:space="preserve">
-    <value>Game Mode automatically prioritizes game processes and suspends Windows Update notifications while gaming for smoother performance.</value>
+    <value>Modo de jogo prioriza automaticamente os processos de jogo e suspende notificações de atualização do Windows durante o jogo para melhor desempenho.</value>
   </data>
   <data name="Customize.Gaming.GameBar.Name" xml:space="preserve">
-    <value>Xbox Game Bar</value>
+    <value>Barra de Jogo do Xbox</value>
   </data>
   <data name="Customize.Gaming.GameBar.Description" xml:space="preserve">
-    <value>Controls Xbox Game Bar overlays, startup panel, and related background features.</value>
+    <value>Controla as sobreposições da Barra de Jogo do Xbox, painel de inicialização e recursos de fundo relacionados.</value>
   </data>
   <data name="Customize.Gaming.GameBar.Recommendation.Reason" xml:space="preserve">
-    <value>Disabling Game Bar frees up system resources and prevents background overlays from interfering with your games.</value>
+    <value>Desativar a Barra de Jogo libera recursos do sistema e impede que sobreposições de fundo interfiram com seus jogos.</value>
   </data>
   <data name="Customize.Gaming.BackgroundRecording.Name" xml:space="preserve">
-    <value>Background Recording (DVR)</value>
+    <value>Gravação em Segundo Plano (DVR)</value>
   </data>
   <data name="Customize.Gaming.BackgroundRecording.Description" xml:space="preserve">
-    <value>Controls automatic background game recording (Game DVR) and app capture.</value>
+    <value>Controla a gravação automática em segundo plano (Game DVR) e captura de aplicativos.</value>
   </data>
   <data name="Customize.Gaming.BackgroundRecording.Recommendation.Reason" xml:space="preserve">
-    <value>Disabling background recording stops DVR from silently capturing gameplay, saving CPU and disk write cycles.</value>
+    <value>Desativar a gravação em segundo plano impede que DVR capture silenciosamente a jogabilidade, economizando ciclos de CPU e escrita de disco.</value>
   </data>
   <data name="Customize.Gaming.MouseAcceleration.Name" xml:space="preserve">
-    <value>Mouse Acceleration</value>
+    <value>Aceleração do Mouse</value>
   </data>
   <data name="Customize.Gaming.MouseAcceleration.Description" xml:space="preserve">
-    <value>Windows mouse acceleration setting for cursor movement.</value>
+    <value>Configuração de aceleração do mouse do Windows para movimento do cursor.</value>
   </data>
   <data name="Customize.Gaming.MouseAcceleration.Recommendation.Reason" xml:space="preserve">
-    <value>Disabling acceleration gives you raw, linear mouse input for better aim precision and muscle memory consistency.</value>
+    <value>Desativar a aceleração fornece entrada de mouse linear e precisa para melhor precisão de mira e consistência de memória muscular.</value>
   </data>
   <data name="Customize.Gaming.FullscreenOptimizations.Name" xml:space="preserve">
-    <value>Fullscreen Optimizations</value>
+    <value>Otimizações de Tela Cheia</value>
   </data>
   <data name="Customize.Gaming.FullscreenOptimizations.Description" xml:space="preserve">
-    <value>Windows DWM-based full-screen optimizations setting.</value>
+    <value>Configuração de otimizações de tela cheia baseadas no DWM do Windows.</value>
   </data>
   <data name="Customize.Gaming.FullscreenOptimizations.Recommendation.Reason" xml:space="preserve">
-    <value>Disable it if you experience in-game stuttering, input lag, or black screens (especially in competitive shooters).</value>
+    <value>Desative se você experimentar travamentos na tela, latência de entrada ou telas pretas (especialmente em jogos de tiro competitivos).</value>
   </data>
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Name" xml:space="preserve">
-    <value>Hardware-Accelerated GPU Scheduling</value>
+    <value>Agendamento de GPU Acelerado por Hardware</value>
   </data>
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Description" xml:space="preserve">
-    <value>GPU video memory scheduling mode. Requires a compatible GPU driver.</value>
+    <value>Modo de agendamento de memória de vídeo da GPU. Requer um driver de GPU compatível.</value>
   </data>
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
-    <value>GPU scheduling offloads frame management from the CPU to the GPU, cutting display latency and improving frame pacing.</value>
+    <value>Agendamento de GPU delega a gestão de quadros do CPU para a GPU, reduzindo a latência de exibição e melhorando a fluência.</value>
   </data>
   <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
-    <value>Do NOT change unless you know exactly what you are doing</value>
+    <value>NÃO altere a menos que você saiba exatamente o que está fazendo</value>
   </data>
   <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DownloadFailed" xml:space="preserve">
-    <value>Failed to download optimizerDuck's power plan.</value>
+    <value>Falha ao baixar o plano de energia do optimizerDuck.</value>
   </data>
   <data name="Settings.About.Acknowledgements.Title" xml:space="preserve">
-    <value>Acknowledgments</value>
+    <value>Agradecimentos</value>
   </data>
   <data name="Settings.About.Acknowledgements.Description" xml:space="preserve">
-    <value>optimizerDuck is made possible by the following open-source software and resources.</value>
+    <value>O optimizerDuck é possível graças aos seguintes softwares e recursos de código aberto.</value>
   </data>
   <data name="RestorePoint.Title" xml:space="preserve">
-    <value>System Restore</value>
+    <value>Restauração do Sistema</value>
   </data>
   <data name="RestorePointDialog.Description" xml:space="preserve">
-    <value>Restore Point allows you to revert your system to a previous state.
-It's a safety measure to protect your Windows before applying changes.</value>
+    <value>O Ponto de Restauração permite reverter seu sistema para um estado anterior.
+É uma medida de segurança para proteger seu Windows antes de aplicar alterações.</value>
   </data>
   <data name="RestorePointDialog.Help" xml:space="preserve">
-    <value>The application will automatically enable System Restore and create a checkpoint named "optimizerDuck...".
-This ensures you can always go back if anything goes wrong.</value>
+    <value>O aplicativo habilitará automaticamente a Restauração do Sistema e criará um checkpoint nomeado "optimizerDuck...".
+Isso garante que você possa sempre voltar se algo der errado.</value>
   </data>
   <data name="RestorePoint.Snackbar.Error.Title" xml:space="preserve">
-    <value>Unable to create or enable System Restore.</value>
+    <value>Não foi possível criar ou habilitar a Restauração do Sistema.</value>
   </data>
   <data name="RestorePoint.Snackbar.Error.Message" xml:space="preserve">
-    <value>An error occurred while creating or enabling System Restore. Please try creating it manually.</value>
+    <value>Ocorreu um erro ao criar ou habilitar a Restauração do Sistema. Por favor, tente criá-lo manualmente.</value>
   </data>
   <data name="RestorePoint.Snackbar.Warning.LimitReached" xml:space="preserve">
-    <value>A restore point has already been created within the past 24 hours.</value>
+    <value>Um ponto de restauração já foi criado nos últimos 24 horas.</value>
   </data>
   <data name="RestorePoint.Progress.Creating" xml:space="preserve">
-    <value>Creating a restore point...</value>
+    <value>Criando um ponto de restauração...</value>
   </data>
   <data name="RestorePoint.Progress.Enabling" xml:space="preserve">
-    <value>Enabling System Restore...</value>
+    <value>Habilitando a Restauração do Sistema...</value>
   </data>
   <data name="RestorePoint.Progress.Retrying" xml:space="preserve">
-    <value>Retrying to create the restore point...</value>
+    <value>Tentando criar o ponto de restauração...</value>
   </data>
   <data name="RestorePoint.Snackbar.Success.Title" xml:space="preserve">
-    <value>Restore point created successfully</value>
+    <value>Ponto de restauração criado com sucesso</value>
   </data>
   <data name="RestorePoint.Snackbar.Success.Message" xml:space="preserve">
-    <value>A restore point has been created with the name: {0}.</value>
+    <value>Um ponto de restauração foi criado com o nome: {0}.</value>
   </data>
   <data name="Snackbar.OpenLinkFailed.Title" xml:space="preserve">
-    <value>Unable to open the path</value>
+    <value>Não foi possível abrir o caminho</value>
   </data>
   <data name="Snackbar.OpenLinkFailed.Message" xml:space="preserve">
-    <value>An error occurred while opening the path. Please check the log.</value>
+    <value>Ocorreu um erro ao abrir o caminho. Por favor, verifique o log.</value>
   </data>
   <data name="Snackbar.OpenFailed.Message" xml:space="preserve">
-    <value>An error occurred while opening the folder or file. Please check the log.</value>
+    <value>Ocorreu um erro ao abrir a pasta ou arquivo. Por favor, verifique o log.</value>
   </data>
   <data name="Snackbar.OpenFailed.Title" xml:space="preserve">
-    <value>Unable to open the folder or file</value>
+    <value>Não foi possível abrir a pasta ou arquivo</value>
   </data>
   <data name="Button.ViewLatestRelease" xml:space="preserve">
-    <value>View latest release</value>
+    <value>Visualizar a versão mais recente</value>
   </data>
   <data name="BloatwareDialog.Title" xml:space="preserve">
-    <value>Removing {0} AppX Package(s)</value>
+    <value>Removendo {0} Pacote(s) AppX</value>
   </data>
   <data name="BloatwareDialog.Removing" xml:space="preserve">
-    <value>Removing {0} ({1}/{2})</value>
+    <value>Removendo {0} ({1}/{2})</value>
   </data>
   <data name="Bloatware.Header.Title" xml:space="preserve">
-    <value>Bloatware</value>
+    <value>Software Inútil</value>
   </data>
   <data name="Bloatware.Menu.Remove" xml:space="preserve">
-    <value>Remove ({0})</value>
+    <value>Remover ({0})</value>
   </data>
   <data name="Bloatware.Menu.Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Atualizar</value>
   </data>
   <data name="Bloatware.Empty.Title" xml:space="preserve">
-    <value>No unnecessary apps found ¯\_(ツ)_/¯</value>
+    <value>Nenhum aplicativo inútil encontrado ¯\_(ツ)_/¯</value>
   </data>
   <data name="Bloatware.Empty.Description" xml:space="preserve">
-    <value>optimizerDuck didn't find any removable AppX packages. It's empty as a void...</value>
+    <value>O optimizerDuck não encontrou nenhum pacote AppX removível. Está vazio como o vácuo...</value>
   </data>
   <data name="Bloatware.Loading" xml:space="preserve">
-    <value>Looking for removable apps...</value>
+    <value>Procurando aplicativos removíveis...</value>
   </data>
   <data name="Bloatware.Loading.Hint" xml:space="preserve">
-    <value>This may take a moment while the application scans for installed packages.</value>
+    <value>Isso pode levar um momento enquanto o aplicativo escaneia os pacotes instalados.</value>
   </data>
   <data name="Sidebar.Bloatware" xml:space="preserve">
-    <value>Bloatware</value>
+    <value>Software Inútil</value>
   </data>
   <data name="BloatwareDialog.Confirmation.Title" xml:space="preserve">
-    <value>Remove {0} App(s)?</value>
+    <value>Remover {0} Aplicativo(s)?</value>
   </data>
   <data name="BloatwareDialog.Confirmation.Message" xml:space="preserve">
-    <value>You are about to remove: {0}</value>
+    <value>Você está prestes a remover: {0}</value>
   </data>
   <data name="BloatwareDialog.Confirmation.Description" xml:space="preserve">
-    <value>Review the selected apps before removal. Proceed only if you are sure.</value>
+    <value>Revise os aplicativos selecionados antes da remoção. Proceda apenas se você estiver certo.</value>
   </data>
   <data name="BloatwareDialog.Confirmation.SelectedList" xml:space="preserve">
-    <value>Selected applications</value>
+    <value>Aplicativos selecionados</value>
   </data>
   <data name="Settings.Bloatware.Header" xml:space="preserve">
-    <value>Bloatware</value>
+    <value>Software Inútil</value>
   </data>
   <data name="Settings.Bloatware.RemoveProvisioned.Title" xml:space="preserve">
-    <value>Remove Provisioned packages</value>
+    <value>Remover Pacotes Provisionados</value>
   </data>
   <data name="Settings.Bloatware.RemoveProvisioned.Description" xml:space="preserve">
-    <value>When removing installed AppX packages, also remove the corresponding Provisioned packages to prevent automatic reinstallation for new users.</value>
+    <value>Ao remover pacotes AppX instalados, também remova os pacotes Provisionados correspondentes para evitar a re-instalação automática para novos usuários.</value>
   </data>
   <data name="Dashboard.UpdateInfoBar.Message" xml:space="preserve">
-    <value>optimizerDuck (v{0}) is available!
-Update now to enjoy the latest features, improvements, and bug fixes.</value>
+    <value>O optimizerDuck (v{0}) está disponível!
+Atualize agora para desfrutar das últimas funcionalidades, melhorias e correções de bugs.</value>
   </data>
   <data name="Common.Search.Placeholder" xml:space="preserve">
-    <value>Search...</value>
+    <value>Buscar...</value>
   </data>
   <data name="Common.Filter.All" xml:space="preserve">
-    <value>All</value>
+    <value>Todos</value>
   </data>
   <data name="Common.SortBy.Default" xml:space="preserve">
-    <value>Default</value>
+    <value>Padrão</value>
   </data>
   <data name="Common.SortBy.Name" xml:space="preserve">
-    <value>Name</value>
+    <value>Nome</value>
   </data>
   <data name="Common.SortBy.Risk" xml:space="preserve">
-    <value>Risk</value>
+    <value>Risco</value>
   </data>
   <data name="Common.SortBy.Publisher" xml:space="preserve">
-    <value>Publisher</value>
+    <value>Publicador</value>
   </data>
   <data name="Common.SortBy.Size" xml:space="preserve">
-    <value>Size</value>
+    <value>Tamanho</value>
   </data>
   <data name="Common.SortBy.Path" xml:space="preserve">
-    <value>Path</value>
+    <value>Caminho</value>
   </data>
   <data name="Optimizer.Menu.ApplyAllSafe" xml:space="preserve">
-    <value>Apply All Safe</value>
+    <value>Aplicar Todos Seguros</value>
   </data>
   <data name="Optimizer.Menu.ApplyAll" xml:space="preserve">
-    <value>Apply Everything</value>
+    <value>Aplicar Tudo</value>
   </data>
   <data name="Optimizer.Menu.ViewSource" xml:space="preserve">
-    <value>View Source</value>
+    <value>Visualizar Fonte</value>
   </data>
   <data name="Bloatware.Menu.SelectAllSafe" xml:space="preserve">
-    <value>Select all Safe</value>
+    <value>Selecionar Todos Seguros</value>
   </data>
   <data name="Bloatware.Menu.DeselectAllSafe" xml:space="preserve">
-    <value>Deselect all Safe</value>
+    <value>Desselecionar Todos Seguros</value>
   </data>
   <data name="Optimizer.Menu.HideApplied" xml:space="preserve">
-    <value>Hide Applied</value>
+    <value>Ocultar Aplicados</value>
   </data>
   <data name="Optimizer.Menu.ApplyMenu" xml:space="preserve">
-    <value>Apply</value>
+    <value>Aplicar</value>
   </data>
   <data name="Optimizer.Menu.BatchApply.Title" xml:space="preserve">
-    <value>Applying Optimizations</value>
+    <value>Aplicando Otimizações</value>
   </data>
   <data name="Bloatware.Search.NoResults" xml:space="preserve">
-    <value>No results found. Try a different search term or filter.</value>
+    <value>Nenhum resultado encontrado. Tente um termo de busca diferente ou filtro.</value>
   </data>
   <data name="Common.Filter" xml:space="preserve">
-    <value>Filter</value>
+    <value>Filtro</value>
   </data>
   <data name="Common.SortBy" xml:space="preserve">
-    <value>Sort by</value>
+    <value>Ordenar por</value>
   </data>
   <data name="Sidebar.DiskCleanup" xml:space="preserve">
-    <value>Disk Cleanup</value>
+    <value>Limpeza de Disco</value> 
   </data>
   <data name="DiskCleanup.Header.Title" xml:space="preserve">
-    <value>Disk Cleanup</value>
+    <value>Limpeza de Disco</value>
   </data>
   <data name="DiskCleanup.Header.Description" xml:space="preserve">
-    <value>Free up disk space by removing temporary files and cache</value>
+    <value>Libere espaço no disco removendo arquivos temporários e cache</value>
   </data>
   <data name="DiskCleanup.TotalSpace" xml:space="preserve">
-    <value>Total reclaimable space</value>
+    <value>Total de espaço recuperável</value>
   </data>
   <data name="DiskCleanup.Button.Scan" xml:space="preserve">
-    <value>Scan</value>
+    <value>Escanear</value>
   </data>
   <data name="DiskCleanup.Button.SelectAll" xml:space="preserve">
-    <value>Select All</value>
+    <value>Selecionar Todos</value>
   </data>
   <data name="DiskCleanup.Button.DeselectAll" xml:space="preserve">
-    <value>Deselect All</value>
+    <value>Desselecionar Todos</value>
   </data>
   <data name="DiskCleanup.Scanning" xml:space="preserve">
-    <value>Scanning...</value>
+    <value>Escaneando...</value>
   </data>
   <data name="DiskCleanup.Loading" xml:space="preserve">
-    <value>Loading cleanup items...</value>
+    <value>Carregando itens de limpeza...</value>
   </data>
   <data name="DiskCleanup.Complete.Title" xml:space="preserve">
-    <value>Cleanup Complete</value>
+    <value>Limpeza Completa</value>
   </data>
   <data name="DiskCleanup.Complete.Message" xml:space="preserve">
-    <value>Successfully freed {0} of disk space in {1}</value>
+    <value>Sucesso ao liberar {0} de espaço no disco em {1}</value> 
   </data>
   <data name="DiskCleanup.Error.Title" xml:space="preserve">
-    <value>Cleanup Error</value>
+    <value>Erro de Limpeza</value>
   </data>
   <data name="DiskCleanup.Error.Message" xml:space="preserve">
-    <value>Some files could not be deleted. They may be in use by another process.</value>
+    <value>Alguns arquivos não puderam ser deletados. Eles podem estar em uso por outro processo.</value>
   </data>
   <data name="DiskCleanup.Item.TempFiles" xml:space="preserve">
-    <value>Temporary Files</value>
+    <value>Arquivos Temporários</value>
   </data>
   <data name="DiskCleanup.Item.TempFiles.Description" xml:space="preserve">
-    <value>User temporary files created by applications (excluding the .net temp directory)</value>
+    <value>Arquivos temporários criados pelos aplicativos (excluindo o diretório .net temp)</value>
   </data>
   <data name="DiskCleanup.Item.SystemTemp" xml:space="preserve">
-    <value>System Temp Files</value>
+    <value>Arquivos Temporários do Sistema</value>
   </data>
   <data name="DiskCleanup.Item.SystemTemp.Description" xml:space="preserve">
-    <value>Windows system temporary files</value>
+    <value>Arquivos temporários do sistema do Windows</value>
   </data>
   <data name="DiskCleanup.Item.WindowsUpdate" xml:space="preserve">
-    <value>Windows Update Cache</value>
+    <value>Cache de Atualizações do Windows</value>
   </data>
   <data name="DiskCleanup.Item.WindowsUpdate.Description" xml:space="preserve">
-    <value>Downloaded Windows Update files that are no longer needed</value>
+    <value>Arquivos do Windows Update que não são mais necessários</value>
   </data>
   <data name="DiskCleanup.Item.Prefetch" xml:space="preserve">
-    <value>Prefetch Files</value>
+    <value>Arquivos Prefetch</value>
   </data>
   <data name="DiskCleanup.Item.Prefetch.Description" xml:space="preserve">
-    <value>Application prefetch data used to speed up loading</value>
+    <value>Dados de prefetch dos aplicativos usados para acelerar o carregamento</value>
   </data>
   <data name="DiskCleanup.Item.Thumbnails" xml:space="preserve">
-    <value>Thumbnail Cache</value>
+    <value>Cache de Miniaturas</value>
   </data>
   <data name="DiskCleanup.Item.Thumbnails.Description" xml:space="preserve">
-    <value>Cached thumbnail images for Explorer file previews</value>
+    <value>Imagens em cache para visualizações de arquivos no Explorer</value>
   </data>
   <data name="DiskCleanup.Item.RecycleBin" xml:space="preserve">
-    <value>Recycle Bin</value>
+    <value>Lixeira</value>
   </data>
   <data name="DiskCleanup.Item.RecycleBin.Description" xml:space="preserve">
-    <value>Deleted files still stored in the Recycle Bin</value>
+    <value>Arquivos deletados ainda armazenados na Lixeira</value>
   </data>
   <data name="DiskCleanup.Item.ErrorReports" xml:space="preserve">
-    <value>Error Reports</value>
+    <value>Relatórios de Erros</value>
   </data>
   <data name="DiskCleanup.Item.ErrorReports.Description" xml:space="preserve">
-    <value>Windows error reports and crash dump files</value>
+    <value>Relatórios de erros do Windows e arquivos de dump de falha</value>
   </data>
   <data name="DiskCleanup.Item.OldWindowsInstallation" xml:space="preserve">
-    <value>Old Windows Installation (Windows.old)</value>
+    <value>Instalação Antiga do Windows (Windows.old)</value>
   </data>
   <data name="DiskCleanup.Item.OldWindowsInstallation.Description" xml:space="preserve">
-    <value>Previous Windows installation files kept after a major update or upgrade</value>
+    <value>Arquivos de instalação do Windows anteriores mantidos após uma atualização ou upgrade major</value>
   </data>
   <data name="Dashboard.SystemInfo.Os.DeviceType.Laptop" xml:space="preserve">
-    <value>Laptop</value>
+    <value>Notebook</value>
   </data>
   <data name="Dashboard.SystemInfo.Os.DeviceType.Desktop" xml:space="preserve">
     <value>Desktop</value>
   </data>
   <data name="Dashboard.SystemInfo.Os.Build" xml:space="preserve">
-    <value>Build {0}</value>
+    <value>Compilação {0}</value>
   </data>
   <data name="Bloatware.Header.Description" xml:space="preserve">
-    <value>Manage and remove pre-installed applications that you don't need</value>
+    <value>Gerencie e remova aplicativos pré-instalados que você não precisa</value>
   </data>
   <data name="Dashboard.SystemInfo.Header" xml:space="preserve">
-    <value>System Information</value>
+    <value>Informação do Sistema</value>
   </data>
   <data name="DiskCleanup.ItemsSelected" xml:space="preserve">
-    <value>{0} ({1} items selected)</value>
+    <value>{0} ({1} itens selecionados)</value>
   </data>
   <data name="DiskCleanup.Button.Clean" xml:space="preserve">
-    <value>Clean</value>
+    <value>Limpar</value>
   </data>
   <data name="DiskCleanup.Button.CleanSelected" xml:space="preserve">
-    <value>Clean Selected ({0})</value>
+    <value>Limpar Selecionados ({0})</value>
   </data>
   <data name="DiskCleanup.EmptySize" xml:space="preserve">
-    <value>Empty size</value>
+    <value>Tamanho vazio</value>
   </data>
   <data name="DiskCleanup.FilesCount" xml:space="preserve">
-    <value>{0} files</value>
+    <value>{0} arquivos</value>
   </data>
   <data name="DiskCleanup.ItemsAndFilesSelected" xml:space="preserve">
-    <value>{0} selected • {1} items • {2} files</value>
+    <value>{0} selecionados • {1} itens • {2} arquivos</value>
   </data>
   <data name="Settings.About.NeedHelp.Title" xml:space="preserve">
-      <value>Need help?</value>
+      <value>Precisa de ajuda?</value>
     </data>
   <data name="Sidebar.StartupManager" xml:space="preserve">
-    <value>Startup Manager</value>
+    <value>Gerenciador de Inicialização</value>
   </data>
   <data name="StartupManager.Header.Title" xml:space="preserve">
-    <value>Startup Manager</value>
+    <value>Gerenciador de Inicialização</value>
   </data>
   <data name="StartupManager.Header.Description" xml:space="preserve">
-    <value>Manage applications and tasks that run automatically when Windows starts.</value>
+    <value>Gerencie aplicativos e tarefas que são executados automaticamente quando o Windows inicia.</value>
   </data>
   <data name="OptimizationDetailsDialog.Other" xml:space="preserve">
-    <value>Other</value>
+    <value>Outro</value>
   </data>
   <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Description" xml:space="preserve">
-    <value>Open the raw json file containing revert data for this optimization.</value>
+    <value>Abra o arquivo json bruto contendo os dados de reversão para esta otimização.</value>
   </data>
   <data name="OptimizationDetailsDialog.Other.ViewSource.Description" xml:space="preserve">
-    <value>Open the source code for this optimization in your browser.</value>
+    <value>Abra o código fonte para esta otimização em seu navegador.</value>
   </data>
   <data name="OptimizationDetailsDialog.Other.ViewSource.Title" xml:space="preserve">
-    <value>View Source on GitHub</value>
+    <value>Visualizar Fonte no GitHub</value>
   </data>
   <data name="OptimizationDetailsDialog.Risk" xml:space="preserve">
-    <value>Risk Level</value>
+    <value>Nível de Risco</value>
   </data>
   <data name="OptimizationDetailsDialog.TechnicalDetails" xml:space="preserve">
-    <value>Technical Details</value>
+    <value>Detalhes Técnicos</value>
   </data>
   <data name="OptimizationDetailsDialog.Id" xml:space="preserve">
-    <value>Optimization ID</value>
+    <value>ID de Otimização</value>
   </data>
   <data name="OptimizationDetailsDialog.Class" xml:space="preserve">
-    <value>Class Name</value>
+    <value>Nome da Classe</value>
   </data>
   <data name="StartupManager.Apps.Title" xml:space="preserve">
-    <value>Startup Apps</value>
+    <value>Aplicativos de Inicialização</value>
   </data>
   <data name="StartupManager.Apps.Description" xml:space="preserve">
-    <value>Applications that run automatically when Windows starts.</value>
+    <value>Aplicativos que são executados automaticamente quando o Windows inicia.</value>
   </data>
   <data name="StartupManager.Apps.CountSuffix" xml:space="preserve">
-    <value>{0} items</value>
+    <value>{0} itens</value>
   </data>
   <data name="StartupManager.Tasks.Title" xml:space="preserve">
-    <value>Scheduled Tasks (Logon)</value>
+    <value>Tarefas Agendadas (Logon)</value>
   </data>
   <data name="StartupManager.Tasks.Description" xml:space="preserve">
-    <value>Windows tasks configured to run at logon or on a schedule.</value>
+    <value>Tarefas do Windows configuradas para serem executadas no logon ou em uma agenda.</value>
   </data>
   <data name="StartupManager.Tasks.CountSuffix" xml:space="preserve">
-    <value>{0} tasks</value>
+    <value>{0} tarefas</value>
   </data>
   <data name="StartupManager.Loading" xml:space="preserve">
-    <value>Scanning startup items...</value>
+    <value>Escaneando itens de inicialização...</value>
   </data>
   <data name="StartupManager.Loading.Hint" xml:space="preserve">
-    <value>This may take a moment while the application scans the registry and startup folders.</value>
+    <value>Isso pode levar um momento enquanto o aplicativo escaneia o registro e as pastas de inicialização.</value>
   </data>
   <data name="StartupManager.Empty.Title" xml:space="preserve">
-    <value>No startup items</value>
+    <value>Nenhum item de inicialização</value>
   </data>
   <data name="StartupManager.Empty.Description" xml:space="preserve">
-    <value>No startup applications or scheduled tasks were found on this system.</value>
+    <value>Nenhum aplicativo de inicialização ou tarefa agendada foi encontrado neste sistema.</value>
   </data>
   <data name="StartupManager.Menu.Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Atualizar</value>
   </data>
   <data name="Common.Toggle.On" xml:space="preserve">
-    <value>On</value>
+    <value>Ligado</value>
   </data>
   <data name="Common.Toggle.Off" xml:space="preserve">
-    <value>Off</value>
+    <value>Desligado</value>
   </data>
   <data name="Common.SortBy.Status" xml:space="preserve">
     <value>Status</value>
   </data>
   <data name="Common.Status.Applied" xml:space="preserve">
-    <value>Applied</value>
+    <value>Aplicado</value>
   </data>
   <data name="StartupManager.Menu.OpenSettings" xml:space="preserve">
-    <value>Open Settings</value>
+    <value>Abrir Configurações</value>
   </data>
   <!-- Scheduled Tasks (Startup Manager) -->
   <data name="StartupManager.Tasks.HideMicrosoft" xml:space="preserve">
-    <value>Hide Microsoft tasks</value>
+    <value>Ocultar Tarefas Microsoft</value>
   </data>
   <!-- Sidebar -->
   <data name="Sidebar.ScheduledTasks" xml:space="preserve">
-    <value>Scheduled Tasks</value>
+    <value>Tarefas Agendadas</value>
   </data>
   <!-- Scheduled Tasks Page -->
   <data name="ScheduledTasks.Header.Title" xml:space="preserve">
-    <value>Scheduled Tasks</value>
+    <value>Tarefas Agendadas</value>
   </data>
   <data name="ScheduledTasks.Header.Description" xml:space="preserve">
-    <value>View and manage Windows scheduled tasks.</value>
+    <value>Visualize e gerencie as tarefas agendadas do Windows.</value>
   </data>
   <data name="ScheduledTasks.Loading" xml:space="preserve">
-    <value>Loading scheduled tasks...</value>
+    <value>Carregando tarefas agendadas...</value>
   </data>
   <data name="ScheduledTasks.Loading.Hint" xml:space="preserve">
-    <value>This may take a moment while scanning for all scheduled tasks on your system...</value>
+    <value>Isso pode levar um momento enquanto escaneia todas as tarefas agendadas em seu sistema...</value>
   </data>
   <data name="ScheduledTasks.HideMicrosoft" xml:space="preserve">
-    <value>Hide Microsoft tasks</value>
+    <value>Ocultar Tarefas Microsoft</value>
   </data>
   <data name="ScheduledTasks.Menu.CreateTask" xml:space="preserve">
-    <value>Create Task</value>
+    <value>Criar Tarefa</value>
   </data>
   <!-- Scheduled Tasks Actions -->
   <data name="ScheduledTasks.Action.Details" xml:space="preserve">
-    <value>View Details</value>
+    <value>Visualizar Detalhes</value>
   </data>
   <data name="ScheduledTasks.Action.Run" xml:space="preserve">
-    <value>Run</value>
+    <value>Executar</value>
   </data>
   <data name="ScheduledTasks.Action.Stop" xml:space="preserve">
-    <value>Stop</value>
+    <value>Parar</value>
   </data>
   <data name="ScheduledTasks.Action.Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>Deletar</value>
   </data>
   <!-- Scheduled Tasks Dialogs -->
   <data name="ScheduledTasks.Dialog.DeleteTitle" xml:space="preserve">
-    <value>Delete Scheduled Task</value>
+    <value>Deletar Tarefa Agendada</value>
   </data>
   <data name="ScheduledTasks.Dialog.DeleteMessage" xml:space="preserve">
-    <value>Are you sure you want to delete the task "{0}"? This action cannot be undone.</value>
+    <value>Tem certeza que deseja deletar a tarefa "{0}"? Esta ação não pode ser desfeita.</value>
   </data>
   <!-- Scheduled Tasks Details -->
   <data name="ScheduledTasks.Details.Path" xml:space="preserve">
-    <value>Path</value>
+    <value>Caminho</value>
   </data>
   <data name="ScheduledTasks.Details.Description" xml:space="preserve">
-    <value>Description</value>
+    <value>Descrição</value>
   </data>
   <data name="ScheduledTasks.Details.Author" xml:space="preserve">
-    <value>Author</value>
+    <value>Autor</value>
   </data>
   <data name="ScheduledTasks.Details.State" xml:space="preserve">
-    <value>State</value>
+    <value>Estado</value>
   </data>
   <data name="ScheduledTasks.Details.Triggers" xml:space="preserve">
     <value>Triggers</value>
   </data>
   <data name="ScheduledTasks.Details.Action" xml:space="preserve">
-    <value>Action</value>
+    <value>Ação</value>
   </data>
   <data name="ScheduledTasks.Details.LastRun" xml:space="preserve">
-    <value>Last Run</value>
+    <value>Última Execução</value>
   </data>
   <data name="ScheduledTasks.Details.NextRun" xml:space="preserve">
-    <value>Next Run</value>
+    <value>Próxima Execução</value>
   </data>
   <data name="ScheduledTasks.Details.LastResult" xml:space="preserve">
-    <value>Last Result</value>
+    <value>Último Resultado</value>
   </data>
   <!-- Common -->
   <data name="Common.Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>Deletar</value>
   </data>
   <data name="Common.Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Cancelar</value>
   </data>
   <data name="Common.SortBy.State" xml:space="preserve">
-    <value>State</value>
+    <value>Estado</value>
   </data>
   <data name="ScheduledTasks.Menu.OpenSettings" xml:space="preserve">
-    <value>Open Task Scheduler</value>
+    <value>Abrir Gerenciador de Tarefas</value>
   </data>
   <data name="ScheduledTasks.Details.Name" xml:space="preserve">
-    <value>Name</value>
+    <value>Nome</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Enabled.Title" xml:space="preserve">
-    <value>Task Enabled</value>
+    <value>Tarefa Habilitada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Disabled.Title" xml:space="preserve">
-    <value>Task Disabled</value>
+    <value>Tarefa Desabilitada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Toggle.Message" xml:space="preserve">
-    <value>{0} has been updated successfully.</value>
+    <value>{0} foi atualizado com sucesso.</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Run.Title" xml:space="preserve">
-    <value>Task Started</value>
+    <value>Tarefa Iniciada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Run.Message" xml:space="preserve">
-    <value>{0} is now running.</value>
+    <value>{0} está agora em execução.</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Stop.Title" xml:space="preserve">
-    <value>Task Stopped</value>
+    <value>Tarefa Parada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Stop.Message" xml:space="preserve">
-    <value>{0} has been stopped.</value>
+    <value>{0} foi parada.</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Delete.Title" xml:space="preserve">
-    <value>Task Deleted</value>
+    <value>Tarefa Deletada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Delete.Message" xml:space="preserve">
-    <value>{0} has been deleted.</value>
+    <value>{0} foi deletada.</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Create.Title" xml:space="preserve">
-    <value>Task Created</value>
+    <value>Tarefa Criada</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Create.Message" xml:space="preserve">
-    <value>{0} has been created successfully.</value>
+    <value>{0} foi criada com sucesso.</value>
   </data>
   <data name="ScheduledTasks.Snackbar.Error.Title" xml:space="preserve">
 
-    <value>Error</value>
+    <value>Erro</value>
   </data>
   <data name="Settings.About.NeedHelp.Description" xml:space="preserve">
-      <value>If you need help with optimization or have any questions, please join our community for quick support.</value>
+      <value>Se você precisar de ajuda com otimização ou tiver alguma dúvida, por favor, junte-se à nossa comunidade para suporte rápido.</value>
     </data>
   <data name="ScheduledTasks.Error.TaskNotFound" xml:space="preserve">
-      <value>Task not found: {0}</value>
+      <value>Tarefa não encontrada: {0}</value>
     </data>
   <data name="Service.Registry.Name" xml:space="preserve">
-    <value>Registry</value>
+    <value>Registro</value>
   </data>
   <data name="Service.Service.Name" xml:space="preserve">
-    <value>Service</value>
+    <value>Serviço</value>
   </data>
   <data name="Service.ScheduledTask.Name" xml:space="preserve">
-    <value>Scheduled Task</value>
+    <value>Tarefa Agendada</value>
   </data>
   <data name="Service.Shell.Name" xml:space="preserve">
     <value>Shell</value>
   </data>
   <data name="Service.Registry.Description.Write" xml:space="preserve">
-    <value>Write registry value: {0}\{1}</value>
+    <value>Escrever valor de registro: {0}\{1}</value>
   </data>
   <data name="Service.Registry.Description.Delete" xml:space="preserve">
-    <value>Delete registry value: {0}\{1}</value>
+    <value>Deletar valor de registro: {0}\{1}</value>
   </data>
   <data name="Service.Service.Description.Change" xml:space="preserve">
-    <value>Change service '{0}' to {1} startup</value>
+    <value>Mudar serviço '{0}' para {1} inicialização</value>
   </data>
   <data name="Service.ScheduledTask.Description.Enable" xml:space="preserve">
-    <value>Enable scheduled task: {0}</value>
+    <value>Habilitar tarefa agendada: {0}</value>
   </data>
   <data name="Service.ScheduledTask.Description.Disable" xml:space="preserve">
-    <value>Disable scheduled task: {0}</value>
+    <value>Desabilitar tarefa agendada: {0}</value>
   </data>
   <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedDisable" xml:space="preserve">
-    <value>Access denied disabling task {0}</value>
+    <value>Acesso negado ao desabilitar tarefa {0}</value>
   </data>
   <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedEnable" xml:space="preserve">
-    <value>Access denied enabling task {0}</value>
+    <value>Acesso negado ao habilitar tarefa {0}</value>
   </data>
   <data name="Revert.Registry.Description.Restore" xml:space="preserve">
-    <value>Restore registry value: {0}\{1}</value>
+    <value>Restaurar valor de registro: {0}\{1}</value>
   </data>
   <data name="Revert.Registry.Description.Delete" xml:space="preserve">
-    <value>Delete registry value: {0}\{1}</value>
+    <value>Deletar valor de registro: {0}\{1}</value>
   </data>
   <data name="Revert.Service.Description.Restore" xml:space="preserve">
-    <value>Restore service '{0}' to {1} startup</value>
+    <value>Restaurar serviço '{0}' para {1} inicialização</value>
   </data>
   <data name="Revert.ScheduledTask.Description.Enable" xml:space="preserve">
-    <value>Enable scheduled task: {0}</value>
+    <value>Habilitar tarefa agendada: {0}</value>
   </data>
   <data name="Revert.ScheduledTask.Description.Disable" xml:space="preserve">
-    <value>Disable scheduled task: {0}</value>
+    <value>Desabilitar tarefa agendada: {0}</value>
   </data>
   <data name="Revert.Shell.Description.Run" xml:space="preserve">
-    <value>Run {0} command: {1}</value>
+    <value>Executar comando {0}: {1}</value>
   </data>
   <data name="Revert.Shell.Error.UnknownShellType" xml:space="preserve">
-    <value>Unknown shell type</value>
+    <value>Tipo de shell desconhecido</value>
   </data>
   <data name="Revert.Shell.Error.CommandFailed" xml:space="preserve">
-    <value>Revert command failed with exit code {0}</value>
+    <value>Comando de reversão falhou com código de saída {0}</value>
   </data>
   <data name="Revert.UsbPower.Error.CommandFailed" xml:space="preserve">
-    <value>USB power revert failed with exit code {0}</value>
+    <value>Reversão de energia USB falhou com código de saída {0}</value>
   </data>
   <data name="Settings.Optimize.ShowCompletionNotification.Title" xml:space="preserve">
-    <value>Show completion notification</value>
+    <value>Mostrar notificação de conclusão</value>
   </data>
   <data name="Settings.Optimize.ShowCompletionNotification.Description" xml:space="preserve">
-    <value>Displays a notification when optimizations have been successfully applied or reverted.</value>
+    <value>Exibe uma notificação quando as otimizações foram aplicadas ou revertidas com sucesso.</value>
   </data>
   <data name="Optimizations.Loading" xml:space="preserve">
-    <value>Loading optimizations...</value>
+    <value>Carregando otimizações...</value>
   </data>
   <data name="Optimizations.Loading.Hint" xml:space="preserve">
-    <value>Please wait...</value>
+    <value>Por favor, aguarde...</value>
   </data>
   <data name="Common.OpenFolder" xml:space="preserve">
-    <value>Open Folder</value>
+    <value>Abrir Pasta</value>
   </data>
   <data name="Common.Other" xml:space="preserve">
-    <value>Other</value>
+    <value>Outro</value>
   </data>
   <data name="Sidebar.Customize" xml:space="preserve">
-    <value>Customize</value>
+    <value>Personalizar</value>
   </data>
   <data name="Customize.Title" xml:space="preserve">
-    <value>Customize</value>
+    <value>Personalizar</value>
   </data>
   <data name="Customize.SystemFeatures.Name" xml:space="preserve">
-    <value>System</value>
+    <value>Sistema</value>
   </data>
   <data name="Customize.SystemFeatures.Description" xml:space="preserve">
-    <value>Core system features and behaviors</value>
+    <value>Recursos e comportamentos do sistema</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Boot" xml:space="preserve">
-    <value>Boot Operations</value>
+    <value>Operações de Inicialização</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
-    <value>Input Settings</value>
+    <value>Configurações de Entrada</value>
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
-    <value>NumLock on Boot</value>
+    <value>NumLock na Inicialização</value>
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Description" xml:space="preserve">
-    <value>NumLock state at the Windows login screen.</value>
+    <value>Estado do NumLock na tela de login do Windows.</value>
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
-    <value>Enabling NumLock at boot ensures the numpad is ready immediately after login, avoiding manual toggling each time.</value>
+    <value>Habilitar NumLock na inicialização garante que o teclado numérico esteja pronto imediatamente após o login, evitando o manuseio manual cada vez.</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Services" xml:space="preserve">
-    <value>Services</value>
+    <value>Serviços</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
-    <value>Power Settings</value>
+    <value>Configurações de Energia</value>
   </data>
   <data name="Customize.Desktop.Name" xml:space="preserve">
-    <value>Desktop</value>
+    <value>Área de Trabalho</value>
   </data>
   <data name="Customize.Desktop.Description" xml:space="preserve">
-    <value>Desktop icons and shortcut settings</value>
+    <value>Ícones e configurações de atalhos da área de trabalho</value>
   </data>
   <data name="Customize.Desktop.Section.Icons" xml:space="preserve">
-    <value>Desktop Icons</value>
+    <value>Ícones da Área de Trabalho</value>
   </data>
   <data name="Customize.Desktop.Section.Behaviors" xml:space="preserve">
-    <value>Shortcut Behaviors</value>
+    <value>Comportamentos de Atalhos</value>
   </data>
   <data name="Customize.Desktop.ShowThisPc.Name" xml:space="preserve">
-    <value>This PC</value>
+    <value>Este Computador</value>
   </data>
   <data name="Customize.Desktop.ShowThisPc.Description" xml:space="preserve">
-    <value>Displays the This PC icon on your desktop</value>
+    <value>Exibe o ícone Este Computador na área de trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowRecycleBin.Name" xml:space="preserve">
-    <value>Recycle Bin</value>
+    <value>Lixeira</value>
   </data>
   <data name="Customize.Desktop.ShowRecycleBin.Description" xml:space="preserve">
-    <value>Displays the Recycle Bin icon on your desktop</value>
+    <value>Exibe o ícone da Lixeira na área de trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowUserFiles.Name" xml:space="preserve">
-    <value>User Files</value>
+    <value>Arquivos do Usuário</value>
   </data>
   <data name="Customize.Desktop.ShowUserFiles.Description" xml:space="preserve">
-    <value>Displays your user profile folder as a desktop icon</value>
+    <value>Exibe a pasta do perfil do usuário como um ícone na área de trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowNetwork.Name" xml:space="preserve">
-    <value>Network</value>
+    <value>Rede</value>
   </data>
   <data name="Customize.Desktop.ShowNetwork.Description" xml:space="preserve">
-    <value>Displays the Network icon on your desktop</value>
+    <value>Exibe o ícone da Rede na área de trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowControlPanel.Name" xml:space="preserve">
-    <value>Control Panel</value>
+    <value>Painel de Controle</value>
   </data>
   <data name="Customize.Desktop.ShowControlPanel.Description" xml:space="preserve">
-    <value>Displays the Control Panel icon on your desktop</value>
+    <value>Exibe o ícone do Painel de Controle na área de trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowDesktopIcons.Name" xml:space="preserve">
-    <value>Desktop Icons</value>
+    <value>Ícones da Área de Trabalho</value>
   </data>
   <data name="Customize.Desktop.ShowDesktopIcons.Description" xml:space="preserve">
-    <value>Shows or hides all desktop icons at once</value>
+    <value>Mostra ou oculta todos os ícones da área de trabalho de uma vez</value>
   </data>
   <data name="Customize.Desktop.ShortcutArrow.Name" xml:space="preserve">
-    <value>Shortcut Arrow</value>
+    <value>Seta de Atalho</value>
   </data>
   <data name="Customize.Desktop.ShortcutArrow.Description" xml:space="preserve">
-    <value>Shows or hides the shortcut arrow overlay on desktop icons</value>
+    <value>Mostra ou oculta a sobreposição da seta de atalho nos ícones da área de trabalho</value>
   </data>
   <data name="Customize.Preferences.LaunchToThisPc.Name" xml:space="preserve">
-    <value>Launch to "This PC"</value>
+    <value>Iniciar em "Este Computador"</value>
   </data>
   <data name="Customize.Preferences.LaunchToThisPc.Description" xml:space="preserve">
-    <value>File Explorer default location setting (This PC or Quick Access).</value>
+    <value>Configuração de localização padrão do Explorer de Arquivos (Este PC ou Acesso Rápido).</value>
   </data>
   <data name="Customize.Preferences.BingSearch.Name" xml:space="preserve">
-    <value>Bing Search</value>
+    <value>Busca Bing</value>
   </data>
   <data name="Customize.Preferences.BingSearch.Description" xml:space="preserve">
-    <value>Bing web search integration in Windows Search and Start menu results.</value>
+    <value>Integração da busca web Bing nos resultados da Busca do Windows e do Menu Iniciar.</value>
   </data>
   <data name="Customize.Preferences.BingSearch.Recommendation.Reason" xml:space="preserve">
-    <value>Turning off Bing search prevents web queries from cluttering local search results and improves search speed.</value>
+    <value>Desativar a busca Bing impede que consultas web poluam os resultados da busca local e melhora a velocidade da busca.</value>
   </data>
   <data name="Button.Accept" xml:space="preserve">
-    <value>Accept</value>
+    <value>Aceitar</value>
   </data>
   <data name="LegalDialog.Title" xml:space="preserve">
-    <value>Legal Agreement</value>
+    <value>Acordo Legal</value>
   </data>
   <data name="LegalDialog.Intro.ThankYou" xml:space="preserve">
-    <value>Thank you for choosing optimizerDuck.</value>
+    <value>Obrigado por escolher o optimizerDuck.</value>
   </data>
   <data name="LegalDialog.Intro.Safety" xml:space="preserve">
-    <value>To ensure transparency and your safety, optimizerDuck may adjust certain system settings and registry configurations.</value>
+    <value>Para garantir transparência e sua segurança, o optimizerDuck pode ajustar certas configurações do sistema e configurações do registro.</value>
   </data>
   <data name="LegalDialog.Intro.Review" xml:space="preserve">
-    <value>Please take a moment to review the following documents. By continuing, you agree to these terms.</value>
+    <value>Por favor, dedique um momento para revisar os seguintes documentos. Ao continuar, você concorda com estes termos.</value>
   </data>
   <data name="LegalDialog.Link.TermsOfService" xml:space="preserve">
-    <value>Terms of Service</value>
+    <value>Termos de Serviço</value>
   </data>
   <data name="LegalDialog.Link.PrivacyPolicy" xml:space="preserve">
-    <value>Privacy Policy</value>
+    <value>Política de Privacidade</value>
   </data>
   <data name="LegalDialog.Link.Disclaimer" xml:space="preserve">
-    <value>Disclaimer</value>
+    <value>Aviso de Isenção de Responsabilidade</value>
   </data>
   <data name="LegalDialog.Warning.Title" xml:space="preserve">
-    <value>Use at your own risk</value>
+    <value>Use por sua conta e risco</value>
   </data>
   <data name="LegalDialog.Warning.Message" xml:space="preserve">
-    <value>We recommend creating a backup before applying any changes.</value>
+    <value>Recomendamos criar um backup antes de aplicar quaisquer alterações.</value>
   </data>
   <data name="Dialog.PendingChanges.Title" xml:space="preserve">
-    <value>Apply Changes</value>
+    <value>Aplicar Alterações</value>
   </data>
   <data name="Dialog.PendingChanges.Content" xml:space="preserve">
-    <value>Some changes require a restart to take effect. What would you like to do before exiting?</value>
+    <value>Algumas alterações requerem um reinício para ter efeito. O que você gostaria de fazer antes de sair?</value>
   </data>
   <data name="Dialog.PendingChanges.CloseButton" xml:space="preserve">
-    <value>Exit Anyway</value>
+    <value>Sair Mesmo Assim</value>
   </data>
   <data name="Dialog.PendingChanges.PrimaryButton" xml:space="preserve">
-    <value>Restart PC</value>
+    <value>Reiniciar PC</value>
   </data>
   <data name="Dialog.PendingChanges.SecondaryButton" xml:space="preserve">
-    <value>Restart Explorer</value>
+    <value>Reiniciar Explorer</value>
   </data>
   <data name="Settings.About.Documentation.Title" xml:space="preserve">
-    <value>Documentation</value>
+    <value>Documentação</value>
   </data>
   <data name="Settings.About.Documentation.Description" xml:space="preserve">
-    <value>View documentation, usage guides, and FAQs.</value>
+    <value>Visualize documentação, guias de uso e perguntas frequentes.</value>
   </data>
   <data name="TitleBar.Support" xml:space="preserve">
-    <value>Support the Project</value>
+    <value>Suporte ao Projeto</value>
   </data>
   <data name="TitleBar.Discord" xml:space="preserve">
-    <value>Join the Discord community</value>
+    <value>Junte-se à comunidade Discord</value>
   </data>
 </root>

--- a/optimizerDuck/Resources/Languages/Translations.pt-BR.resx
+++ b/optimizerDuck/Resources/Languages/Translations.pt-BR.resx
@@ -1,0 +1,1806 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+        Microsoft ResX Schema 
+        
+        Version 2.0
+        
+        The primary goals of this format is to allow a simple XML format 
+        that is mostly human readable. The generation and parsing of the 
+        various data types are done through the TypeConverter classes 
+        associated with the data types.
+        
+        Example:
+        
+        ... ado.net/XML headers & schema ...
+        <resheader name="resmimetype">text/microsoft-resx</resheader>
+        <resheader name="version">2.0</resheader>
+        <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+        <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+        <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+        <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+        <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+            <value>[base64 mime encoded serialized .NET Framework object]</value>
+        </data>
+        <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+            <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+            <comment>This is a comment</comment>
+        </data>
+                    
+        There are any number of "resheader" rows that contain simple 
+        name/value pairs.
+        
+        Each data row contains a name, and value. The row also contains a 
+        type or mimetype. Type corresponds to a .NET class that support 
+        text/value conversion through the TypeConverter architecture. 
+        Classes that don't support this are serialized and stored with the 
+        mimetype set.
+        
+        The mimetype is used for serialized objects, and tells the 
+        ResXResourceReader how to depersist the object. This is currently not 
+        extensible. For a given mimetype the value must be set accordingly:
+        
+        Note - application/x-microsoft.net.object.binary.base64 is the format 
+        that the ResXResourceWriter will generate, however the reader can 
+        read any of the formats listed below.
+        
+        mimetype: application/x-microsoft.net.object.binary.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+                : and then encoded with base64 encoding.
+        
+        mimetype: application/x-microsoft.net.object.soap.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+                : and then encoded with base64 encoding.
+    
+        mimetype: application/x-microsoft.net.object.bytearray.base64
+        value   : The object must be serialized into a byte array 
+                : using a System.ComponentModel.TypeConverter
+                : and then encoded with base64 encoding.
+        -->
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root" xmlns="">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <data name="Dashboard.Header.Title" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="Sidebar.Dashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="Sidebar.Settings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Cores" xml:space="preserve">
+    <value>{0} Cores</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.DiskInfo" xml:space="preserve">
+    <value>{0} GB usados de {1} GB ({2} GB livres)</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Modules" xml:space="preserve">
+    <value>{0} Módulo(s)</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Threads" xml:space="preserve">
+    <value>{0} Threads</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.System" xml:space="preserve">
+    <value>SISTEMA</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.Header" xml:space="preserve">
+    <value>Storage</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Used" xml:space="preserve">
+    <value>{0} GB Usado</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Available" xml:space="preserve">
+    <value>{0} GB Disponível</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Loading" xml:space="preserve">
+    <value>Buscando informações do sistema...</value>
+  </data>
+  <data name="Sidebar.Optimize" xml:space="preserve">
+    <value>Otimizar</value>
+  </data>
+  <data name="Customize.Description" xml:space="preserve">
+    <value>Personalize as configurações e preferências do Windows</value>
+  </data>
+  <data name="Customize.Preferences.Name" xml:space="preserve">
+    <value>Preferências</value>
+  </data>
+  <data name="Customize.Preferences.Description" xml:space="preserve">
+    <value>Personalize as configurações visuais e de interação</value>
+  </data>
+  <data name="Customize.Gaming.Name" xml:space="preserve">
+    <value>Jogos</value>
+  </data>
+  <data name="Customize.Gaming.Description" xml:space="preserve">
+    <value>Configurações relacionadas a exibição, entrada e gravação de jogos</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Gpu.More" xml:space="preserve">
+    <value>+ {0} mais GPU</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Title" xml:space="preserve">
+    <value>Comunidade do Discord</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Description" xml:space="preserve">
+    <value>Entre na minha comunidade do Discord para obter suporte ou jogar jogos comigo</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Title" xml:space="preserve">
+    <value>Repositório do GitHub</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Description" xml:space="preserve">
+    <value>Explore, revise e contribua para meu projeto através do GitHub</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Title" xml:space="preserve">
+    <value>Apoie-me</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Description" xml:space="preserve">
+    <value>Dê uma estrela no repositório no GitHub, compartilhe com amigos, ou doe qualquer coisa ajuda este projeto a crescer!</value>
+  </data>
+  <data name="Service.Registry.Description.CreateKey" xml:space="preserve">
+    <value>Criar chave do registro {0}</value>
+  </data>
+  <data name="Service.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>Excluir chave do registro {0}</value>
+  </data>
+  <data name="Settings.LanguageChanged.Title" xml:space="preserve">
+    <value>Idioma alterado</value>
+  </data>
+  <data name="Settings.LanguageChanged.Description" xml:space="preserve">
+    <value>Você precisa reiniciar o aplicativo para aplicar o novo idioma.</value>
+  </data>
+  <data name="Button.Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Settings.Header.Title" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="Settings.Appearance.Header" xml:space="preserve">
+    <value>Aparência</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Title" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Description" xml:space="preserve">
+    <value>Escolha seu idioma preferido.</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Title" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Description" xml:space="preserve">
+    <value>Escolha seu tema preferido para o aplicativo.</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Light" xml:space="preserve">
+    <value>Claro</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Dark" xml:space="preserve">
+    <value>Escuro</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.HighContrast" xml:space="preserve">
+    <value>Alto Contraste</value>
+  </data>
+  <data name="Common.AppliedSecondsAgo" xml:space="preserve">
+    <value>Aplicado a {0} segundos atrás</value>
+  </data>
+  <data name="Common.AppliedMinutesAgo" xml:space="preserve">
+    <value>Aplicado a {0} minutos atrás</value>
+  </data>
+  <data name="Common.AppliedHoursAgo" xml:space="preserve">
+    <value>Aplicado a {0} horas atrás</value>
+  </data>
+  <data name="Common.AppliedDaysAgo" xml:space="preserve">
+    <value>Aplicado a {0} dias atrás</value>
+  </data>
+  <data name="Common.AppliedMonthsAgo" xml:space="preserve">
+    <value>Aplicado a {0} meses atrás</value>
+  </data>
+  <data name="Common.AppliedYearsAgo" xml:space="preserve">
+    <value>Aplicado a {0} anos atrás</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Safe" xml:space="preserve">
+    <value>Seguro</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Moderate" xml:space="preserve">
+    <value>Moderação</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Risky" xml:space="preserve">
+    <value>Expert</value>
+  </data>
+  <data name="OptimizationDetailsDialog.DetailedDescription" xml:space="preserve">
+    <value>Descrição detalhada</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.ShortDescription" xml:space="preserve">
+    <value>Define o limite de divisão do Service Host para corresponder ao total de RAM do sistema, forçando o Windows a isolar serviços em processos separados para melhor estabilidade.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DetectActivePlanFailed" xml:space="preserve">
+    <value>Falha ao detectar o plano de energia ativo atual.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ImportFailed" xml:space="preserve">
+    <value>Falha ao importar o plano de energia do optimizerDuck.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ActivateFailed" xml:space="preserve">
+    <value>Falha ao ativar o plano de energia do optimizerDuck.</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Help" xml:space="preserve">
+    <value>Este valor reflete o nível de intervenção e a segurança do processo de otimização. Por favor, tenha cautela e considere cuidadosamente antes de aplicar qualquer otimização.</value>
+  </data>
+  <data name="Optimizer.UI.Tags.System" xml:space="preserve">
+    <value>Sistema</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Ram" xml:space="preserve">
+    <value>RAM</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Disk" xml:space="preserve">
+    <value>Disco</value>
+  </data>
+  <data name="Optimizer.UI.Tags.NetworkRequired" xml:space="preserve">
+    <value>Conexão de rede requerida</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Network" xml:space="preserve">
+    <value>Rede</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Privacy" xml:space="preserve">
+    <value>Privacidade</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Audio" xml:space="preserve">
+    <value>Áudio</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Help" xml:space="preserve">
+    <value>Essas tags indicam quais partes do sistema serão afetadas pela otimização.</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Nvidia" xml:space="preserve">
+    <value>NVIDIA</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Amd" xml:space="preserve">
+    <value>AMD</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Intel" xml:space="preserve">
+    <value>Intel</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Power" xml:space="preserve">
+    <value>Energia</value>
+  </data>
+  <data name="Revert.Error.InvalidData" xml:space="preserve">
+    <value>Dados de reversão inválidos para {0}: {1}</value>
+  </data>
+  <data name="Revert.Error.NoDataFound" xml:space="preserve">
+    <value>Não foi encontrado nenhum dado de reversão para {0}.</value>
+  </data>
+  <data name="Optimization.Revert.Reverting" xml:space="preserve">
+    <value>Revertendo...</value>
+  </data>
+  <data name="Optimization.Revert.Success" xml:space="preserve">
+    <value>Reversão de {0} realizada com sucesso!</value>
+  </data>
+  <data name="Optimization.Revert.Error.FailedWithSteps" xml:space="preserve">
+    <value>Reversão de {0} realizada com {1} etapa(s) falhada(s).</value>
+  </data>
+  <data name="Revert.Error.RevertFailed" xml:space="preserve">
+    <value>Falha ao reverter {0}: {1}</value>
+  </data>
+  <data name="Optimization.Revert.ExecutingStep" xml:space="preserve">
+    <value>Executando etapa de reversão: {0}/{1} ({2})</value>
+  </data>
+  <data name="Optimization.Revert.StepDescription" xml:space="preserve">
+    <value>Etapa de reversão #{0}</value>
+  </data>
+  <data name="Revert.Registry.Description.RestoreKey" xml:space="preserve">
+    <value>Restaurar chave do registro: {0}</value>
+  </data>
+  <data name="Revert.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>Excluir chave do registro: {0}</value>
+  </data>
+  <data name="Revert.Registry.Description.RevertUnknown" xml:space="preserve">
+    <value>Reverter registro: {0}</value>
+  </data>
+  <data name="Revert.Error.FileNotFound" xml:space="preserve">
+    <value>Arquivo de reversão não encontrado</value>
+  </data>
+  <data name="Revert.Error.FileEmpty" xml:space="preserve">
+    <value>Arquivo de reversão está vazio</value>
+  </data>
+  <data name="Revert.Error.ReadFailed" xml:space="preserve">
+    <value>Falha ao ler dados de reversão: {0}</value>
+  </data>
+  <data name="Revert.Error.InvalidJson" xml:space="preserve">
+    <value>Dados de reversão inválidos</value>
+  </data>
+  <data name="Revert.Error.InvalidJsonFormat" xml:space="preserve">
+    <value>Formato de JSON inválido: {0}</value>
+  </data>
+  <data name="Revert.Error.NoSteps" xml:space="preserve">
+    <value>Não foi encontrado nenhum passo de reversão.</value>
+  </data>
+  <data name="Revert.Error.InvalidSteps" xml:space="preserve">
+    <value>Passos de reversão inválidos: {0}</value>
+  </data>
+  <data name="Revert.Error.StepFailed" xml:space="preserve">
+    <value>Etapa de reversão falhou</value>
+  </data>
+  <data name="Revert.UsbPower.Description" xml:space="preserve">
+    <value>Restaurar estados de energia de suspensão seletiva de USB</value>
+  </data>
+  <data name="Service.Registry.Error.BackupTruncated" xml:space="preserve">
+    <value>A subárvore do registro é muito grande para ser copiada com segurança; exclusão abortada para {0}</value>
+  </data>
+  <data name="Revert.Error.OptimizationIdMismatch" xml:space="preserve">
+    <value>OptimizationId não corresponde.</value>
+  </data>
+  <data name="Optimization.Apply.Processing" xml:space="preserve">
+    <value>Aplicando alterações...</value>
+  </data>
+  <data name="Optimization.Apply.Completed" xml:space="preserve">
+    <value>Completado</value>
+  </data>
+  <data name="Optimization.Apply.Success" xml:space="preserve">
+    <value>Aplicado com sucesso {0}.</value>
+  </data>
+  <data name="Optimization.Apply.Error.FailedWithSteps" xml:space="preserve">
+    <value>Aplicado {0} com {1} etapa(s) falhada(s).</value>
+  </data>
+  <data name="Optimization.Apply.Error.Failed" xml:space="preserve">
+    <value>Falha ao aplicar {0}.</value>
+  </data>
+  <data name="Optimization.Apply.Error.Unknown" xml:space="preserve">
+    <value>Resultado desconhecido para {0}.</value>
+  </data>
+  <data name="Service.Common.Error.AccessDenied" xml:space="preserve">
+    <value>Acesso negado</value>
+  </data>
+  <data name="Service.Registry.Error.AccessDeniedProtectedHive" xml:space="preserve">
+    <value>Acesso negado (hives protegidas)</value>
+  </data>
+  <data name="Service.Registry.Error.UnauthorizedAccess" xml:space="preserve">
+    <value>Acesso não autorizado</value>
+  </data>
+  <data name="Service.Registry.Error.CreateOrOpenSubkeyFailed" xml:space="preserve">
+    <value>Falha ao criar/abrir subchave</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedWrite" xml:space="preserve">
+    <value>Acesso negado ao escrever {0}:{1}</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDelete" xml:space="preserve">
+    <value>Acesso negado ao deletar {0}:{1}</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedCreateKey" xml:space="preserve">
+    <value>Acesso negado ao criar {0}</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDeleteKeyTree" xml:space="preserve">
+    <value>Acesso negado ao deletar árvore de chave {0}</value>
+  </data>
+  <data name="Service.Service.Error.NotFound" xml:space="preserve">
+    <value>Serviço não encontrado</value>
+  </data>
+  <data name="Service.Service.Info.SkippedNotFound" xml:space="preserve">
+    <value>Serviço '{0}' não encontrado (pulado)</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartupTypeFailed" xml:space="preserve">
+    <value>Falha ao mudar o tipo de inicialização para o serviço</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartModeFailedWithCode" xml:space="preserve">
+    <value>ChangeStartMode falhou (código: {0})</value>
+  </data>
+  <data name="Service.Service.Error.ExceptionOccurred" xml:space="preserve">
+    <value>Falha ao mudar o serviço '{0}': {1}</value>
+  </data>
+  <data name="Service.Shell.Error.ExitCode" xml:space="preserve">
+    <value>Código de saída {0}</value>
+  </data>
+  <data name="Service.Shell.Error.TimedOut" xml:space="preserve">
+    <value>Tempo esgotado</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Title" xml:space="preserve">
+    <value>Arquivo de reversão</value>
+  </data>
+  <data name="OptimizationResultDialog.Header" xml:space="preserve">
+    <value>{0} Etapas falhadas</value>
+  </data>
+  <data name="OptimizationResultDialog.Description" xml:space="preserve">
+    <value>Algumas etapas não completaram com sucesso. Você pode tentar apenas as etapas falhadas.</value>
+  </data>
+  <data name="OptimizationResultDialog.Details" xml:space="preserve">
+    <value>Detalhes</value>
+  </data>
+  <data name="Button.Retry" xml:space="preserve">
+    <value>Tentar novamente</value>
+  </data>
+  <data name="Settings.About.Duck.Description" xml:space="preserve">
+    <value>Versão atual: {0}</value>
+  </data>
+  <data name="Settings.Advanced.Header" xml:space="preserve">
+    <value>Avançado</value>
+  </data>
+  <data name="Settings.Optimize.Header" xml:space="preserve">
+    <value>Otimizar</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Title" xml:space="preserve">
+    <value>Tempo limite do serviço Shell</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Description" xml:space="preserve">
+    <value>Tempo limite para cada execução de comando shell (milissegundos).</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Title" xml:space="preserve">
+    <value>Limpar downloads</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Description" xml:space="preserve">
+    <value>Excluir todos os arquivos baixados durante o processo de otimização.</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Title" xml:space="preserve">
+    <value>Limpar todos os dados de reversão</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Description" xml:space="preserve">
+    <value>Limpar todos os dados de reversão das otimizações.</value>
+  </data>
+  <data name="Button.Clear" xml:space="preserve">
+    <value>Limpar</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Title" xml:space="preserve">
+    <value>Abrir diretório raiz</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Description" xml:space="preserve">
+    <value>Abrir o diretório raiz da aplicação, onde todos os arquivos necessários são armazenados.</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Title" xml:space="preserve">
+    <value>Scroll suave</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Description" xml:space="preserve">
+    <value>Ativar animação de scroll suave para uma experiência de scroll mais fluida. Desativar se você sentir lentidão.</value>
+  </data>
+  <data name="Button.Open" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="Settings.About.Header" xml:space="preserve">
+    <value>Sobre</value>
+  </data>
+  <data name="Dialog.AreYouSure.Title" xml:space="preserve">
+    <value>Você realmente deseja continuar?</value>
+  </data>
+  <data name="Settings.ClearDownloads.Description" xml:space="preserve">
+    <value>Você está prestes a excluir todos os arquivos baixados durante o processo de otimização. Por favor, note que esta ação é permanente e não pode ser desfeita, então certifique-se de que você está certo antes de continuar.</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Button.Skip" xml:space="preserve">
+    <value>Pular</value>
+  </data>
+  <data name="Settings.ClearRevertData.Description" xml:space="preserve">
+    <value>Você está prestes a excluir todos os dados de reversão gerados após o processo de otimização. Isso significa que você não poderá mais restaurar o estado antes da otimização, então por favor, pense cuidadosamente antes de confirmar.</value>
+  </data>
+  <data name="ProcessingOptimizationDialog.Warning.DontCloseAppOrRestart" xml:space="preserve">
+    <value>Por favor, não feche a aplicação ou reinicie enquanto as alterações são aplicadas ou revertidas.</value>
+  </data>
+  <data name="Common.AppliedJustNow" xml:space="preserve">
+    <value>Aplicado agora</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Error.Title" xml:space="preserve">
+      <value>Não foi possível aplicar a otimização completamente</value>
+    </data>
+  <data name="Optimization.Revert.Snackbar.Error.Title" xml:space="preserve">
+    <value>Não foi possível reverter a otimização</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Success.Title" xml:space="preserve">
+    <value>Otimização aplicada com sucesso</value>
+  </data>
+  <data name="Optimization.Revert.Snackbar.Success.Title" xml:space="preserve">
+    <value>Otimização revertida com sucesso</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Title" xml:space="preserve">
+    <value>Não foi possível alternar a otimização</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Message" xml:space="preserve">
+    <value>Ocorreu um erro: {0}</value>
+  </data>
+  <data name="Optimization.Retry.Processing" xml:space="preserve">
+    <value>Retentando etapas falhadas...</value>
+  </data>
+  <data name="Optimization.RetryStep.Processing" xml:space="preserve">
+    <value>Retentando etapa {0} ({1}/{2} etapas)</value>
+  </data>
+  <data name="Optimization.Revert.Error.Failed" xml:space="preserve">
+    <value>Falha ao reverter {0}.</value>
+  </data>
+  <data name="Dashboard.Header.Menu.Refresh" xml:space="preserve">
+    <value>Atualizar</value>
+  </data>
+  <data name="Dashboard.Header.Menu.RunTaskManager" xml:space="preserve">
+    <value>Gerenciador de Tarefas</value>
+  </data>
+  <data name="Common.Unknown" xml:space="preserve">
+    <value>Desconhecido</value>
+  </data>
+  <data name="Common.Recommendation.On" xml:space="preserve">
+    <value>Recomendado</value>
+  </data>
+  <data name="Common.Recommendation.Off" xml:space="preserve">
+    <value>Não recomendado</value>
+  </data>
+  <data name="Common.Recommendation.Experimental" xml:space="preserve">
+    <value>Experimental</value>
+  </data>
+  <data name="Common.Recommendation.Depends" xml:space="preserve">
+    <value>Depende</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Security" xml:space="preserve">
+    <value>Segurança</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Performance" xml:space="preserve">
+    <value>Performance</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Latency" xml:space="preserve">
+    <value>Latência</value>
+  </data>
+  <data name="Optimizer.Performance" xml:space="preserve">
+    <value>Performance</value>
+  </data>
+  <data name="Optimizer.PowerManagement" xml:space="preserve">
+    <value>Gerenciamento de Energia</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy" xml:space="preserve">
+    <value>Segurança &amp; Privacidade</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices" xml:space="preserve">
+    <value>Software Indesejável &amp; Serviços</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.Name" xml:space="preserve">
+    <value>Desativar Aplicativos em Segundo Plano</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.ShortDescription" xml:space="preserve">
+    <value>Previne que aplicativos inativos sejam executados em segundo plano para liberar RAM e reduzir a sobrecarga do CPU.</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Name" xml:space="preserve">
+    <value>Otimizar Isolamento de Serviços</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Error.InvalidRAM" xml:space="preserve">
+    <value>RAM inválida: {0}</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.Name" xml:space="preserve">
+    <value>Priorizar Aplicativos Ativos</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.ShortDescription" xml:space="preserve">
+    <value>Aloca mais recursos de CPU para o aplicativo que você está usando atualmente para uma experiência mais rápida e responsiva.</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.Name" xml:space="preserve">
+    <value>Otimizar Agendador de Multimídia</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
+    <value>Configura o Serviço de Agendamento de Classes de Multimídia (MMCSS) para jogos e baixa latência priorizando cargas de trabalho de multimídia e desativando a limitação de rede.</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
+    <value>Otimizar Repetição de Teclado</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.ShortDescription" xml:space="preserve">
+    <value>Define o atraso de repetição de teclado mais rápido e a taxa de repetição para uma digitação mais responsiva e pressionamentos de tecla repetidos.</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.Name" xml:space="preserve">
+    <value>Desativar Teclas de Atalho de Teclado de Acessibilidade</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.ShortDescription" xml:space="preserve">
+    <value>Desativa as teclas de atalho de teclado Sticky Keys, Filter Keys e Toggle Keys para evitar pop-ups acidentais durante jogos e digitação.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.Name" xml:space="preserve">
+    <value>Desativar Hibernação &amp; Inicialização Rápida</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.ShortDescription" xml:space="preserve">
+    <value>Desativa a hibernação e a inicialização rápida para recuperar espaço em disco e garantir um desligamento completo para uma inicialização de hardware mais limpa.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.Name" xml:space="preserve">
+    <value>Desativar Economia de Energia USB</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.ShortDescription" xml:space="preserve">
+    <value>Previne que o Windows desligue portas USB, eliminando atrasos de wake-up para mouse, teclado e outros periféricos.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Name" xml:space="preserve">
+    <value>Aplicar Plano de Energia Otimizado</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.ShortDescription" xml:space="preserve">
+    <value>Instala um plano de energia personalizado focado em performance para garantir que seu sistema sempre execute na velocidade máxima. Aviso: Pode fazer o Gerenciador de Tarefas mostrar incorretamente o uso de 100% da CPU em alguns sistemas, enquanto o uso real da CPU não é afetado.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Progress.Importing" xml:space="preserve">
+    <value>Importando e ativando o plano de energia...</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.Name" xml:space="preserve">
+    <value>Desativar Limitação de Energia do Sistema</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.ShortDescription" xml:space="preserve">
+    <value>Previne que o Windows limite a performance da CPU (Limitação de Energia) para manter a potência máxima para tarefas ativas.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Name" xml:space="preserve">
+    <value>Desativar Coleta de Dados (Telemetria)</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.ShortDescription" xml:space="preserve">
+    <value>Desativa os serviços de telemetria e rastreamento de uso do Windows para melhorar sua privacidade pessoal e reduzir a atividade em segundo plano.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.EditRegistry" xml:space="preserve">
+    <value>Aplicando alterações de política e registro...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableServices" xml:space="preserve">
+    <value>Desativando serviços de telemetria...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableTasks" xml:space="preserve">
+    <value>Desativando tarefas programadas de telemetria...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.Name" xml:space="preserve">
+    <value>Desativar Relatório de Erros</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.ShortDescription" xml:space="preserve">
+    <value>Desativa os serviços de Relatório de Erros do Windows e o Assistente de Compatibilidade de Programas.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.Name" xml:space="preserve">
+    <value>Desativar Anúncios e Sugestões</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.ShortDescription" xml:space="preserve">
+    <value>Desativa anúncios personalizados, recursos de consumidor do Windows e sugestões do sistema.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.Name" xml:space="preserve">
+    <value>Desativar Histórico de Atividades</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.ShortDescription" xml:space="preserve">
+    <value>Previne que o Windows colete e sincronize seu histórico de atividades.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.Name" xml:space="preserve">
+    <value>Desativar Localização e Sensores</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.ShortDescription" xml:space="preserve">
+    <value>Desativa o rastreamento de localização, sensores do sistema e atualizações de mapas offline.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.Name" xml:space="preserve">
+    <value>Desativar Log de Segundo Plano</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.ShortDescription" xml:space="preserve">
+    <value>Para o registro de eventos do sistema não essenciais para reduzir a atividade contínua do disco e salvar ciclos de CPU.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.Name" xml:space="preserve">
+    <value>Desativar Cortana &amp; Busca na Web</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.ShortDescription" xml:space="preserve">
+    <value>Desativa o assistente de voz Cortana e remove os resultados da Web do Bing da barra de busca do Windows.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.Name" xml:space="preserve">
+    <value>Desativar Windows Copilot</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.ShortDescription" xml:space="preserve">
+    <value>Remove o assistente AI Copilot da barra de tarefas e da shell do sistema para liberar memória e espaço na tela.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.Name" xml:space="preserve">
+    <value>Desativar Entrega de Conteúdo de Nuvem</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.ShortDescription" xml:space="preserve">
+    <value>Desativa o conteúdo entregado pela nuvem do Windows, incluindo dicas do sistema, sugestões de spotlight e entrega automática de recursos de consumidor.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.Name" xml:space="preserve">
+    <value>Bloquear Software Pré-instalado Indesejável</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.ShortDescription" xml:space="preserve">
+    <value>Previne que o Windows re-instale automaticamente aplicativos de terceiros indesejáveis e software promovido.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Name" xml:space="preserve">
+    <value>Otimizar Serviços do Sistema</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.ShortDescription" xml:space="preserve">
+    <value>Ajusta serviços de segundo plano não essenciais para liberar recursos enquanto mantém todas as funcionalidades necessárias do Windows.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Progress.ChangeServiceStartupType" xml:space="preserve">
+    <value>Configurando o tipo de inicialização para {0} para {1}...</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Display" xml:space="preserve">
+    <value>Exibição</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Visual" xml:space="preserve">
+    <value>Visualização</value> 
+  </data>
+  <data name="Optimizer.Gpu" xml:space="preserve">
+    <value>GPU</value>
+  </data>
+  <data name="Optimizer.UserExperience" xml:space="preserve">
+    <value>Experiência do Usuário</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.Name" xml:space="preserve">
+    <value>Acelerar Explorador &amp; Menus</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
+    <value>Define StartupDelayInMSec=0, MenuShowDelay=0 para eliminar o atraso de inicialização do Explorador e reduzir o atraso de hover do menu para o mínimo.</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.Name" xml:space="preserve">
+    <value>Desativar Efeitos Visuais</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.ShortDescription" xml:space="preserve">
+    <value>Desativa as animações da barra de tarefas, sombras da lista de exibição, transparência da janela e Aero Peek para liberar recursos de GPU/CPU para melhor performance.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.Name" xml:space="preserve">
+    <value>Desativar AMD ULPS</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.ShortDescription" xml:space="preserve">
+    <value>Define EnableULPS=0 no registro da GPU AMD para evitar atrasos de wake-up do Estado de Baixa Potência Ultra e problemas de múltiplos monitores. Reduz a economia de energia no estado inativo.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.Name" xml:space="preserve">
+    <value>Desativar Controle de Energia AMD</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.ShortDescription" xml:space="preserve">
+    <value>Define DisablePowerGating=1, PP_GPUPowerDownEnabled=0, DisableDynamicPstate=1 para prevenir transições de estado de energia da GPU AMD. Mantém clocks consistentes ao custo de maior consumo de energia no estado inativo.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.Name" xml:space="preserve">
+    <value>Desativar Controle de Clock de Vídeo AMD</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.ShortDescription" xml:space="preserve">
+    <value>Sets DisableVCEPowerGating=1, DisableVceClockGating=1, EnableUvdClockGating=0 for AMD video engines (VCE/UVD) to improve encode/decode stability. Increases video playback power.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.Name" xml:space="preserve">
+    <value>Desativar AMD ASPM</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.ShortDescription" xml:space="preserve">
+    <value>Define EnableAspmL0s=0, EnableAspmL1=0 para desativar o Gerenciamento de Estado Ativo na GPU AMD, reduzindo a latência da barramento PCIe. Aumenta o consumo de energia da slot.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.Name" xml:space="preserve">
+    <value>Desativar P-State Dinâmico NVIDIA</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.ShortDescription" xml:space="preserve">
+    <value>Define DisableDynamicPstate=1 para bloquear a GPU NVIDIA em um estado de performance fixo, evitando flutuações de frequência. Aumenta o consumo de energia no estado inativo.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.Name" xml:space="preserve">
+    <value>Desativar NVIDIA Async P-States</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.ShortDescription" xml:space="preserve">
+    <value>Define DisableASyncPstates=1 para prevenir a troca de estado de energia assíncrona da NVIDIA, fornecendo performance determinística para aplicativos VR/tempo real.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.Name" xml:space="preserve">
+    <value>Desativar Intel Async Flips</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.ShortDescription" xml:space="preserve">
+    <value>Define Display1_DisableAsyncFlips=1 para forçar reversões de buffer sincronizadas na iGPU Intel, reduzindo a latência de entrada-exibição e rachaduras de tela.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.Name" xml:space="preserve">
+    <value>Desativar Intel Adaptive V-Sync</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.ShortDescription" xml:space="preserve">
+    <value>Define AdaptiveVsyncEnable=0 para desativar o V-Sync adaptativo da Intel que ajusta dinamicamente à taxa de quadros, usando V-Sync fixo em vez disso para timing estável.</value>
+  </data>
+  <data name="Customize.Preferences.Section.Taskbar" xml:space="preserve">
+    <value>Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.Section.Appearance" xml:space="preserve">
+    <value>Aparência</value>
+  </data>
+  <data name="Customize.Preferences.Section.Explorer" xml:space="preserve">
+    <value>Explorer</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarNewsAndInterests.Name" xml:space="preserve">
+    <value>Notícias e Interesses da Barra de Tarefas</value> 
+  </data>
+  <data name="Customize.Preferences.TaskbarNewsAndInterests.Description" xml:space="preserve">
+    <value>Controla o widget de Notícias e Interesses na barra de tarefas e atualizações de feed do MSN em segundo plano.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarSearchBox.Name" xml:space="preserve">
+    <value>Caixa de Busca da Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarSearchBox.Description" xml:space="preserve">
+    <value>Controls visibility of the search box on the taskbar.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarChatButton.Name" xml:space="preserve">
+    <value>Taskbar Chat Button</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarChatButton.Description" xml:space="preserve">
+    <value>Controls visibility of the Chat (Teams) button on the taskbar.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Name" xml:space="preserve">
+    <value>Taskbar Widgets</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Description" xml:space="preserve">
+    <value>Controls visibility of the Widgets button on the taskbar.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Recommendation.Reason" xml:space="preserve">
+    <value>Turning off widgets removes the background web service that fetches news and weather, reducing idle network and memory usage.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Name" xml:space="preserve">
+    <value>Alinhamento da Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Description" xml:space="preserve">
+    <value>Alterna o alinhamento da barra de tarefas entre Centro e Esquerda.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Center" xml:space="preserve">
+    <value>Centro</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Left" xml:space="preserve">
+    <value>Esquerda</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Name" xml:space="preserve">
+    <value>Modo Compacto do Explorer</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Description" xml:space="preserve">
+    <value>Reduz o espaçamento entre itens no Explorer de arquivos para uma exibição mais densa.</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Name" xml:space="preserve">
+    <value>Flyout de Layout de Snap</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Description" xml:space="preserve">
+    <value>Controla o menu de layouts de snap que aparece quando o cursor passa sobre o botão de maximizar.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Name" xml:space="preserve">
+    <value>Caixas de Seleção do Explorer</value> 
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Description" xml:space="preserve">
+    <value>Mostra caixas de seleção ao selecionar itens no Explorer de arquivos.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Name" xml:space="preserve">
+    <value>Botão de Visualização de Tarefas da Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Description" xml:space="preserve">
+    <value>Controla a visibilidade do botão de visualização de tarefas na barra de tarefas.</value>
+  </data>
+  <data name="Customize.Preferences.MeetNow.Name" xml:space="preserve">
+    <value>Encontrar Agora</value>
+  </data>
+  <data name="Customize.Preferences.MeetNow.Description" xml:space="preserve">
+    <value>Controla o ícone Encontrar Agora (Skype) na área de notificação da barra de tarefas.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarPeople.Name" xml:space="preserve">
+    <value>Pessoas na Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarPeople.Description" xml:space="preserve">
+    <value>Controla o ícone de Pessoas na barra de tarefas para acesso rápido a contatos.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Name" xml:space="preserve">
+    <value>Finalizar Tarefa na Barra de Tarefas</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Description" xml:space="preserve">
+    <value>Adiciona uma opção "Finalizar Tarefa" ao menu de clique direito da barra de tarefas para terminar processos rapidamente.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Recommendation.Reason" xml:space="preserve">
+    <value>Finalizar Tarefa na barra de tarefas permite matar aplicativos travados instantaneamente sem abrir o Gerenciador de Tarefas.</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Name" xml:space="preserve">
+    <value>Modo Escuro</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Description" xml:space="preserve">
+    <value>Modo escuro para aplicativos do sistema, Configurações e elementos da shell.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Name" xml:space="preserve">
+    <value>Notificações de Sincronização do Explorer</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Description" xml:space="preserve">
+    <value>Controla as notificações de sincronização do OneDrive e provedores de sincronização na nuvem no Explorer de arquivos.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Recommendation.Reason" xml:space="preserve">
+    <value>Desativar notificações de sincronização impede que pop-ups do OneDrive interrompam a navegação de arquivos no Explorer.</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Name" xml:space="preserve">
+    <value>Sugestões do Sistema</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Description" xml:space="preserve">
+    <value>Controla as dicas do Windows e sugestões de aplicativos no painel de Configurações.</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Recommendation.Reason" xml:space="preserve">
+    <value>Desativar sugestões do sistema impede que o Windows recomende aplicativos e configurações que você não solicitou.</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Name" xml:space="preserve">
+    <value>Notificações de Toast</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Description" xml:space="preserve">
+    <value>Controla as notificações de pop-up de toast e notificações de tela de bloqueio.</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Name" xml:space="preserve">
+    <value>Mostrar Extensões de Arquivos</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Description" xml:space="preserve">
+    <value>Shows file extensions (e.g. .txt, .exe) in File Explorer.</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Recommendation.Reason" xml:space="preserve">
+    <value>Showing file extensions makes it easy to spot suspicious file types and prevents malware from hiding behind fake icons.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Name" xml:space="preserve">
+    <value>Show Hidden Files</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Description" xml:space="preserve">
+    <value>Shows hidden files and folders in File Explorer.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Recommendation.Reason" xml:space="preserve">
+    <value>Hidden files contain system and config data you may need to manage; showing them gives you full visibility of your system.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Name" xml:space="preserve">
+    <value>Clipboard History</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Description" xml:space="preserve">
+    <value>Clipboard history for multiple copied items accessible with Win+V.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Recommendation.Reason" xml:space="preserve">
+    <value>Clipboard history lets you recall multiple past copies with Win+V, speeding up repetitive copy-paste workflows.</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Name" xml:space="preserve">
+    <value>Window Shake</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Description" xml:space="preserve">
+    <value>Shake a window to minimize all other open windows.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Name" xml:space="preserve">
+    <value>Classic Context Menu</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Description" xml:space="preserve">
+    <value>Windows 10-style context menu on Windows 11.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Recommendation.Reason" xml:space="preserve">
+    <value>The classic menu shows all options at once without the extra click needed to expand Windows 11's condensed menu.</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Name" xml:space="preserve">
+    <value>Seconds in System Clock</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Description" xml:space="preserve">
+    <value>Displays seconds in the taskbar clock.</value>
+  </data>
+  <data name="Customize.Gaming.Section.GameSettings" xml:space="preserve">
+    <value>Game Settings</value>
+  </data>
+  <data name="Customize.Gaming.Section.Input" xml:space="preserve">
+    <value>Input</value>
+  </data>
+  <data name="Customize.Gaming.Section.Display" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Name" xml:space="preserve">
+    <value>Game Mode</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Description" xml:space="preserve">
+    <value>Windows Game Mode for gaming processes and Windows Update behavior.</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Recommendation.Reason" xml:space="preserve">
+    <value>Game Mode automatically prioritizes game processes and suspends Windows Update notifications while gaming for smoother performance.</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Name" xml:space="preserve">
+    <value>Xbox Game Bar</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Description" xml:space="preserve">
+    <value>Controls Xbox Game Bar overlays, startup panel, and related background features.</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Recommendation.Reason" xml:space="preserve">
+    <value>Disabling Game Bar frees up system resources and prevents background overlays from interfering with your games.</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Name" xml:space="preserve">
+    <value>Background Recording (DVR)</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Description" xml:space="preserve">
+    <value>Controls automatic background game recording (Game DVR) and app capture.</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Recommendation.Reason" xml:space="preserve">
+    <value>Disabling background recording stops DVR from silently capturing gameplay, saving CPU and disk write cycles.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Name" xml:space="preserve">
+    <value>Mouse Acceleration</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Description" xml:space="preserve">
+    <value>Windows mouse acceleration setting for cursor movement.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Recommendation.Reason" xml:space="preserve">
+    <value>Disabling acceleration gives you raw, linear mouse input for better aim precision and muscle memory consistency.</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Name" xml:space="preserve">
+    <value>Fullscreen Optimizations</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Description" xml:space="preserve">
+    <value>Windows DWM-based full-screen optimizations setting.</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Recommendation.Reason" xml:space="preserve">
+    <value>Disable it if you experience in-game stuttering, input lag, or black screens (especially in competitive shooters).</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Name" xml:space="preserve">
+    <value>Hardware-Accelerated GPU Scheduling</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Description" xml:space="preserve">
+    <value>GPU video memory scheduling mode. Requires a compatible GPU driver.</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
+    <value>GPU scheduling offloads frame management from the CPU to the GPU, cutting display latency and improving frame pacing.</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
+    <value>Do NOT change unless you know exactly what you are doing</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DownloadFailed" xml:space="preserve">
+    <value>Failed to download optimizerDuck's power plan.</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Title" xml:space="preserve">
+    <value>Acknowledgments</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Description" xml:space="preserve">
+    <value>optimizerDuck is made possible by the following open-source software and resources.</value>
+  </data>
+  <data name="RestorePoint.Title" xml:space="preserve">
+    <value>System Restore</value>
+  </data>
+  <data name="RestorePointDialog.Description" xml:space="preserve">
+    <value>Restore Point allows you to revert your system to a previous state.
+It's a safety measure to protect your Windows before applying changes.</value>
+  </data>
+  <data name="RestorePointDialog.Help" xml:space="preserve">
+    <value>The application will automatically enable System Restore and create a checkpoint named "optimizerDuck...".
+This ensures you can always go back if anything goes wrong.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Title" xml:space="preserve">
+    <value>Unable to create or enable System Restore.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Message" xml:space="preserve">
+    <value>An error occurred while creating or enabling System Restore. Please try creating it manually.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Warning.LimitReached" xml:space="preserve">
+    <value>A restore point has already been created within the past 24 hours.</value>
+  </data>
+  <data name="RestorePoint.Progress.Creating" xml:space="preserve">
+    <value>Creating a restore point...</value>
+  </data>
+  <data name="RestorePoint.Progress.Enabling" xml:space="preserve">
+    <value>Enabling System Restore...</value>
+  </data>
+  <data name="RestorePoint.Progress.Retrying" xml:space="preserve">
+    <value>Retrying to create the restore point...</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Title" xml:space="preserve">
+    <value>Restore point created successfully</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Message" xml:space="preserve">
+    <value>A restore point has been created with the name: {0}.</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Title" xml:space="preserve">
+    <value>Unable to open the path</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Message" xml:space="preserve">
+    <value>An error occurred while opening the path. Please check the log.</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Message" xml:space="preserve">
+    <value>An error occurred while opening the folder or file. Please check the log.</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Title" xml:space="preserve">
+    <value>Unable to open the folder or file</value>
+  </data>
+  <data name="Button.ViewLatestRelease" xml:space="preserve">
+    <value>View latest release</value>
+  </data>
+  <data name="BloatwareDialog.Title" xml:space="preserve">
+    <value>Removing {0} AppX Package(s)</value>
+  </data>
+  <data name="BloatwareDialog.Removing" xml:space="preserve">
+    <value>Removing {0} ({1}/{2})</value>
+  </data>
+  <data name="Bloatware.Header.Title" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="Bloatware.Menu.Remove" xml:space="preserve">
+    <value>Remove ({0})</value>
+  </data>
+  <data name="Bloatware.Menu.Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Bloatware.Empty.Title" xml:space="preserve">
+    <value>No unnecessary apps found ¯\_(ツ)_/¯</value>
+  </data>
+  <data name="Bloatware.Empty.Description" xml:space="preserve">
+    <value>optimizerDuck didn't find any removable AppX packages. It's empty as a void...</value>
+  </data>
+  <data name="Bloatware.Loading" xml:space="preserve">
+    <value>Looking for removable apps...</value>
+  </data>
+  <data name="Bloatware.Loading.Hint" xml:space="preserve">
+    <value>This may take a moment while the application scans for installed packages.</value>
+  </data>
+  <data name="Sidebar.Bloatware" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Title" xml:space="preserve">
+    <value>Remove {0} App(s)?</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Message" xml:space="preserve">
+    <value>You are about to remove: {0}</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Description" xml:space="preserve">
+    <value>Review the selected apps before removal. Proceed only if you are sure.</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.SelectedList" xml:space="preserve">
+    <value>Selected applications</value>
+  </data>
+  <data name="Settings.Bloatware.Header" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Title" xml:space="preserve">
+    <value>Remove Provisioned packages</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Description" xml:space="preserve">
+    <value>When removing installed AppX packages, also remove the corresponding Provisioned packages to prevent automatic reinstallation for new users.</value>
+  </data>
+  <data name="Dashboard.UpdateInfoBar.Message" xml:space="preserve">
+    <value>optimizerDuck (v{0}) is available!
+Update now to enjoy the latest features, improvements, and bug fixes.</value>
+  </data>
+  <data name="Common.Search.Placeholder" xml:space="preserve">
+    <value>Search...</value>
+  </data>
+  <data name="Common.Filter.All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="Common.SortBy.Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="Common.SortBy.Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Common.SortBy.Risk" xml:space="preserve">
+    <value>Risk</value>
+  </data>
+  <data name="Common.SortBy.Publisher" xml:space="preserve">
+    <value>Publisher</value>
+  </data>
+  <data name="Common.SortBy.Size" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="Common.SortBy.Path" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAllSafe" xml:space="preserve">
+    <value>Apply All Safe</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAll" xml:space="preserve">
+    <value>Apply Everything</value>
+  </data>
+  <data name="Optimizer.Menu.ViewSource" xml:space="preserve">
+    <value>View Source</value>
+  </data>
+  <data name="Bloatware.Menu.SelectAllSafe" xml:space="preserve">
+    <value>Select all Safe</value>
+  </data>
+  <data name="Bloatware.Menu.DeselectAllSafe" xml:space="preserve">
+    <value>Deselect all Safe</value>
+  </data>
+  <data name="Optimizer.Menu.HideApplied" xml:space="preserve">
+    <value>Hide Applied</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyMenu" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Optimizer.Menu.BatchApply.Title" xml:space="preserve">
+    <value>Applying Optimizations</value>
+  </data>
+  <data name="Bloatware.Search.NoResults" xml:space="preserve">
+    <value>No results found. Try a different search term or filter.</value>
+  </data>
+  <data name="Common.Filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="Common.SortBy" xml:space="preserve">
+    <value>Sort by</value>
+  </data>
+  <data name="Sidebar.DiskCleanup" xml:space="preserve">
+    <value>Disk Cleanup</value>
+  </data>
+  <data name="DiskCleanup.Header.Title" xml:space="preserve">
+    <value>Disk Cleanup</value>
+  </data>
+  <data name="DiskCleanup.Header.Description" xml:space="preserve">
+    <value>Free up disk space by removing temporary files and cache</value>
+  </data>
+  <data name="DiskCleanup.TotalSpace" xml:space="preserve">
+    <value>Total reclaimable space</value>
+  </data>
+  <data name="DiskCleanup.Button.Scan" xml:space="preserve">
+    <value>Scan</value>
+  </data>
+  <data name="DiskCleanup.Button.SelectAll" xml:space="preserve">
+    <value>Select All</value>
+  </data>
+  <data name="DiskCleanup.Button.DeselectAll" xml:space="preserve">
+    <value>Deselect All</value>
+  </data>
+  <data name="DiskCleanup.Scanning" xml:space="preserve">
+    <value>Scanning...</value>
+  </data>
+  <data name="DiskCleanup.Loading" xml:space="preserve">
+    <value>Loading cleanup items...</value>
+  </data>
+  <data name="DiskCleanup.Complete.Title" xml:space="preserve">
+    <value>Cleanup Complete</value>
+  </data>
+  <data name="DiskCleanup.Complete.Message" xml:space="preserve">
+    <value>Successfully freed {0} of disk space in {1}</value>
+  </data>
+  <data name="DiskCleanup.Error.Title" xml:space="preserve">
+    <value>Cleanup Error</value>
+  </data>
+  <data name="DiskCleanup.Error.Message" xml:space="preserve">
+    <value>Some files could not be deleted. They may be in use by another process.</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles" xml:space="preserve">
+    <value>Temporary Files</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles.Description" xml:space="preserve">
+    <value>User temporary files created by applications (excluding the .net temp directory)</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp" xml:space="preserve">
+    <value>System Temp Files</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp.Description" xml:space="preserve">
+    <value>Windows system temporary files</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate" xml:space="preserve">
+    <value>Windows Update Cache</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate.Description" xml:space="preserve">
+    <value>Downloaded Windows Update files that are no longer needed</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch" xml:space="preserve">
+    <value>Prefetch Files</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch.Description" xml:space="preserve">
+    <value>Application prefetch data used to speed up loading</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails" xml:space="preserve">
+    <value>Thumbnail Cache</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails.Description" xml:space="preserve">
+    <value>Cached thumbnail images for Explorer file previews</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin" xml:space="preserve">
+    <value>Recycle Bin</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin.Description" xml:space="preserve">
+    <value>Deleted files still stored in the Recycle Bin</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports" xml:space="preserve">
+    <value>Error Reports</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports.Description" xml:space="preserve">
+    <value>Windows error reports and crash dump files</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation" xml:space="preserve">
+    <value>Old Windows Installation (Windows.old)</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation.Description" xml:space="preserve">
+    <value>Previous Windows installation files kept after a major update or upgrade</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Laptop" xml:space="preserve">
+    <value>Laptop</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Desktop" xml:space="preserve">
+    <value>Desktop</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.Build" xml:space="preserve">
+    <value>Build {0}</value>
+  </data>
+  <data name="Bloatware.Header.Description" xml:space="preserve">
+    <value>Manage and remove pre-installed applications that you don't need</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Header" xml:space="preserve">
+    <value>System Information</value>
+  </data>
+  <data name="DiskCleanup.ItemsSelected" xml:space="preserve">
+    <value>{0} ({1} items selected)</value>
+  </data>
+  <data name="DiskCleanup.Button.Clean" xml:space="preserve">
+    <value>Clean</value>
+  </data>
+  <data name="DiskCleanup.Button.CleanSelected" xml:space="preserve">
+    <value>Clean Selected ({0})</value>
+  </data>
+  <data name="DiskCleanup.EmptySize" xml:space="preserve">
+    <value>Empty size</value>
+  </data>
+  <data name="DiskCleanup.FilesCount" xml:space="preserve">
+    <value>{0} files</value>
+  </data>
+  <data name="DiskCleanup.ItemsAndFilesSelected" xml:space="preserve">
+    <value>{0} selected • {1} items • {2} files</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Title" xml:space="preserve">
+      <value>Need help?</value>
+    </data>
+  <data name="Sidebar.StartupManager" xml:space="preserve">
+    <value>Startup Manager</value>
+  </data>
+  <data name="StartupManager.Header.Title" xml:space="preserve">
+    <value>Startup Manager</value>
+  </data>
+  <data name="StartupManager.Header.Description" xml:space="preserve">
+    <value>Manage applications and tasks that run automatically when Windows starts.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other" xml:space="preserve">
+    <value>Other</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Description" xml:space="preserve">
+    <value>Open the raw json file containing revert data for this optimization.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Description" xml:space="preserve">
+    <value>Open the source code for this optimization in your browser.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Title" xml:space="preserve">
+    <value>View Source on GitHub</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Risk" xml:space="preserve">
+    <value>Risk Level</value>
+  </data>
+  <data name="OptimizationDetailsDialog.TechnicalDetails" xml:space="preserve">
+    <value>Technical Details</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Id" xml:space="preserve">
+    <value>Optimization ID</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Class" xml:space="preserve">
+    <value>Class Name</value>
+  </data>
+  <data name="StartupManager.Apps.Title" xml:space="preserve">
+    <value>Startup Apps</value>
+  </data>
+  <data name="StartupManager.Apps.Description" xml:space="preserve">
+    <value>Applications that run automatically when Windows starts.</value>
+  </data>
+  <data name="StartupManager.Apps.CountSuffix" xml:space="preserve">
+    <value>{0} items</value>
+  </data>
+  <data name="StartupManager.Tasks.Title" xml:space="preserve">
+    <value>Scheduled Tasks (Logon)</value>
+  </data>
+  <data name="StartupManager.Tasks.Description" xml:space="preserve">
+    <value>Windows tasks configured to run at logon or on a schedule.</value>
+  </data>
+  <data name="StartupManager.Tasks.CountSuffix" xml:space="preserve">
+    <value>{0} tasks</value>
+  </data>
+  <data name="StartupManager.Loading" xml:space="preserve">
+    <value>Scanning startup items...</value>
+  </data>
+  <data name="StartupManager.Loading.Hint" xml:space="preserve">
+    <value>This may take a moment while the application scans the registry and startup folders.</value>
+  </data>
+  <data name="StartupManager.Empty.Title" xml:space="preserve">
+    <value>No startup items</value>
+  </data>
+  <data name="StartupManager.Empty.Description" xml:space="preserve">
+    <value>No startup applications or scheduled tasks were found on this system.</value>
+  </data>
+  <data name="StartupManager.Menu.Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Common.Toggle.On" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="Common.Toggle.Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Common.SortBy.Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Common.Status.Applied" xml:space="preserve">
+    <value>Applied</value>
+  </data>
+  <data name="StartupManager.Menu.OpenSettings" xml:space="preserve">
+    <value>Open Settings</value>
+  </data>
+  <!-- Scheduled Tasks (Startup Manager) -->
+  <data name="StartupManager.Tasks.HideMicrosoft" xml:space="preserve">
+    <value>Hide Microsoft tasks</value>
+  </data>
+  <!-- Sidebar -->
+  <data name="Sidebar.ScheduledTasks" xml:space="preserve">
+    <value>Scheduled Tasks</value>
+  </data>
+  <!-- Scheduled Tasks Page -->
+  <data name="ScheduledTasks.Header.Title" xml:space="preserve">
+    <value>Scheduled Tasks</value>
+  </data>
+  <data name="ScheduledTasks.Header.Description" xml:space="preserve">
+    <value>View and manage Windows scheduled tasks.</value>
+  </data>
+  <data name="ScheduledTasks.Loading" xml:space="preserve">
+    <value>Loading scheduled tasks...</value>
+  </data>
+  <data name="ScheduledTasks.Loading.Hint" xml:space="preserve">
+    <value>This may take a moment while scanning for all scheduled tasks on your system...</value>
+  </data>
+  <data name="ScheduledTasks.HideMicrosoft" xml:space="preserve">
+    <value>Hide Microsoft tasks</value>
+  </data>
+  <data name="ScheduledTasks.Menu.CreateTask" xml:space="preserve">
+    <value>Create Task</value>
+  </data>
+  <!-- Scheduled Tasks Actions -->
+  <data name="ScheduledTasks.Action.Details" xml:space="preserve">
+    <value>View Details</value>
+  </data>
+  <data name="ScheduledTasks.Action.Run" xml:space="preserve">
+    <value>Run</value>
+  </data>
+  <data name="ScheduledTasks.Action.Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="ScheduledTasks.Action.Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <!-- Scheduled Tasks Dialogs -->
+  <data name="ScheduledTasks.Dialog.DeleteTitle" xml:space="preserve">
+    <value>Delete Scheduled Task</value>
+  </data>
+  <data name="ScheduledTasks.Dialog.DeleteMessage" xml:space="preserve">
+    <value>Are you sure you want to delete the task "{0}"? This action cannot be undone.</value>
+  </data>
+  <!-- Scheduled Tasks Details -->
+  <data name="ScheduledTasks.Details.Path" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="ScheduledTasks.Details.Description" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="ScheduledTasks.Details.Author" xml:space="preserve">
+    <value>Author</value>
+  </data>
+  <data name="ScheduledTasks.Details.State" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="ScheduledTasks.Details.Triggers" xml:space="preserve">
+    <value>Triggers</value>
+  </data>
+  <data name="ScheduledTasks.Details.Action" xml:space="preserve">
+    <value>Action</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastRun" xml:space="preserve">
+    <value>Last Run</value>
+  </data>
+  <data name="ScheduledTasks.Details.NextRun" xml:space="preserve">
+    <value>Next Run</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastResult" xml:space="preserve">
+    <value>Last Result</value>
+  </data>
+  <!-- Common -->
+  <data name="Common.Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Common.SortBy.State" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="ScheduledTasks.Menu.OpenSettings" xml:space="preserve">
+    <value>Open Task Scheduler</value>
+  </data>
+  <data name="ScheduledTasks.Details.Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Enabled.Title" xml:space="preserve">
+    <value>Task Enabled</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Disabled.Title" xml:space="preserve">
+    <value>Task Disabled</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Toggle.Message" xml:space="preserve">
+    <value>{0} has been updated successfully.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Title" xml:space="preserve">
+    <value>Task Started</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Message" xml:space="preserve">
+    <value>{0} is now running.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Title" xml:space="preserve">
+    <value>Task Stopped</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Message" xml:space="preserve">
+    <value>{0} has been stopped.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Title" xml:space="preserve">
+    <value>Task Deleted</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Message" xml:space="preserve">
+    <value>{0} has been deleted.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Title" xml:space="preserve">
+    <value>Task Created</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Message" xml:space="preserve">
+    <value>{0} has been created successfully.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Error.Title" xml:space="preserve">
+
+    <value>Error</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Description" xml:space="preserve">
+      <value>If you need help with optimization or have any questions, please join our community for quick support.</value>
+    </data>
+  <data name="ScheduledTasks.Error.TaskNotFound" xml:space="preserve">
+      <value>Task not found: {0}</value>
+    </data>
+  <data name="Service.Registry.Name" xml:space="preserve">
+    <value>Registry</value>
+  </data>
+  <data name="Service.Service.Name" xml:space="preserve">
+    <value>Service</value>
+  </data>
+  <data name="Service.ScheduledTask.Name" xml:space="preserve">
+    <value>Scheduled Task</value>
+  </data>
+  <data name="Service.Shell.Name" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="Service.Registry.Description.Write" xml:space="preserve">
+    <value>Write registry value: {0}\{1}</value>
+  </data>
+  <data name="Service.Registry.Description.Delete" xml:space="preserve">
+    <value>Delete registry value: {0}\{1}</value>
+  </data>
+  <data name="Service.Service.Description.Change" xml:space="preserve">
+    <value>Change service '{0}' to {1} startup</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>Enable scheduled task: {0}</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>Disable scheduled task: {0}</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedDisable" xml:space="preserve">
+    <value>Access denied disabling task {0}</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedEnable" xml:space="preserve">
+    <value>Access denied enabling task {0}</value>
+  </data>
+  <data name="Revert.Registry.Description.Restore" xml:space="preserve">
+    <value>Restore registry value: {0}\{1}</value>
+  </data>
+  <data name="Revert.Registry.Description.Delete" xml:space="preserve">
+    <value>Delete registry value: {0}\{1}</value>
+  </data>
+  <data name="Revert.Service.Description.Restore" xml:space="preserve">
+    <value>Restore service '{0}' to {1} startup</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>Enable scheduled task: {0}</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>Disable scheduled task: {0}</value>
+  </data>
+  <data name="Revert.Shell.Description.Run" xml:space="preserve">
+    <value>Run {0} command: {1}</value>
+  </data>
+  <data name="Revert.Shell.Error.UnknownShellType" xml:space="preserve">
+    <value>Unknown shell type</value>
+  </data>
+  <data name="Revert.Shell.Error.CommandFailed" xml:space="preserve">
+    <value>Revert command failed with exit code {0}</value>
+  </data>
+  <data name="Revert.UsbPower.Error.CommandFailed" xml:space="preserve">
+    <value>USB power revert failed with exit code {0}</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Title" xml:space="preserve">
+    <value>Show completion notification</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Description" xml:space="preserve">
+    <value>Displays a notification when optimizations have been successfully applied or reverted.</value>
+  </data>
+  <data name="Optimizations.Loading" xml:space="preserve">
+    <value>Loading optimizations...</value>
+  </data>
+  <data name="Optimizations.Loading.Hint" xml:space="preserve">
+    <value>Please wait...</value>
+  </data>
+  <data name="Common.OpenFolder" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="Common.Other" xml:space="preserve">
+    <value>Other</value>
+  </data>
+  <data name="Sidebar.Customize" xml:space="preserve">
+    <value>Customize</value>
+  </data>
+  <data name="Customize.Title" xml:space="preserve">
+    <value>Customize</value>
+  </data>
+  <data name="Customize.SystemFeatures.Name" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Customize.SystemFeatures.Description" xml:space="preserve">
+    <value>Core system features and behaviors</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Boot" xml:space="preserve">
+    <value>Boot Operations</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
+    <value>Input Settings</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
+    <value>NumLock on Boot</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Description" xml:space="preserve">
+    <value>NumLock state at the Windows login screen.</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
+    <value>Enabling NumLock at boot ensures the numpad is ready immediately after login, avoiding manual toggling each time.</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Services" xml:space="preserve">
+    <value>Services</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
+    <value>Power Settings</value>
+  </data>
+  <data name="Customize.Desktop.Name" xml:space="preserve">
+    <value>Desktop</value>
+  </data>
+  <data name="Customize.Desktop.Description" xml:space="preserve">
+    <value>Desktop icons and shortcut settings</value>
+  </data>
+  <data name="Customize.Desktop.Section.Icons" xml:space="preserve">
+    <value>Desktop Icons</value>
+  </data>
+  <data name="Customize.Desktop.Section.Behaviors" xml:space="preserve">
+    <value>Shortcut Behaviors</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Name" xml:space="preserve">
+    <value>This PC</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Description" xml:space="preserve">
+    <value>Displays the This PC icon on your desktop</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Name" xml:space="preserve">
+    <value>Recycle Bin</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Description" xml:space="preserve">
+    <value>Displays the Recycle Bin icon on your desktop</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Name" xml:space="preserve">
+    <value>User Files</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Description" xml:space="preserve">
+    <value>Displays your user profile folder as a desktop icon</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Name" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Description" xml:space="preserve">
+    <value>Displays the Network icon on your desktop</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Name" xml:space="preserve">
+    <value>Control Panel</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Description" xml:space="preserve">
+    <value>Displays the Control Panel icon on your desktop</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Name" xml:space="preserve">
+    <value>Desktop Icons</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Description" xml:space="preserve">
+    <value>Shows or hides all desktop icons at once</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Name" xml:space="preserve">
+    <value>Shortcut Arrow</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Description" xml:space="preserve">
+    <value>Shows or hides the shortcut arrow overlay on desktop icons</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Name" xml:space="preserve">
+    <value>Launch to "This PC"</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Description" xml:space="preserve">
+    <value>File Explorer default location setting (This PC or Quick Access).</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Name" xml:space="preserve">
+    <value>Bing Search</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Description" xml:space="preserve">
+    <value>Bing web search integration in Windows Search and Start menu results.</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Recommendation.Reason" xml:space="preserve">
+    <value>Turning off Bing search prevents web queries from cluttering local search results and improves search speed.</value>
+  </data>
+  <data name="Button.Accept" xml:space="preserve">
+    <value>Accept</value>
+  </data>
+  <data name="LegalDialog.Title" xml:space="preserve">
+    <value>Legal Agreement</value>
+  </data>
+  <data name="LegalDialog.Intro.ThankYou" xml:space="preserve">
+    <value>Thank you for choosing optimizerDuck.</value>
+  </data>
+  <data name="LegalDialog.Intro.Safety" xml:space="preserve">
+    <value>To ensure transparency and your safety, optimizerDuck may adjust certain system settings and registry configurations.</value>
+  </data>
+  <data name="LegalDialog.Intro.Review" xml:space="preserve">
+    <value>Please take a moment to review the following documents. By continuing, you agree to these terms.</value>
+  </data>
+  <data name="LegalDialog.Link.TermsOfService" xml:space="preserve">
+    <value>Terms of Service</value>
+  </data>
+  <data name="LegalDialog.Link.PrivacyPolicy" xml:space="preserve">
+    <value>Privacy Policy</value>
+  </data>
+  <data name="LegalDialog.Link.Disclaimer" xml:space="preserve">
+    <value>Disclaimer</value>
+  </data>
+  <data name="LegalDialog.Warning.Title" xml:space="preserve">
+    <value>Use at your own risk</value>
+  </data>
+  <data name="LegalDialog.Warning.Message" xml:space="preserve">
+    <value>We recommend creating a backup before applying any changes.</value>
+  </data>
+  <data name="Dialog.PendingChanges.Title" xml:space="preserve">
+    <value>Apply Changes</value>
+  </data>
+  <data name="Dialog.PendingChanges.Content" xml:space="preserve">
+    <value>Some changes require a restart to take effect. What would you like to do before exiting?</value>
+  </data>
+  <data name="Dialog.PendingChanges.CloseButton" xml:space="preserve">
+    <value>Exit Anyway</value>
+  </data>
+  <data name="Dialog.PendingChanges.PrimaryButton" xml:space="preserve">
+    <value>Restart PC</value>
+  </data>
+  <data name="Dialog.PendingChanges.SecondaryButton" xml:space="preserve">
+    <value>Restart Explorer</value>
+  </data>
+  <data name="Settings.About.Documentation.Title" xml:space="preserve">
+    <value>Documentation</value>
+  </data>
+  <data name="Settings.About.Documentation.Description" xml:space="preserve">
+    <value>View documentation, usage guides, and FAQs.</value>
+  </data>
+  <data name="TitleBar.Support" xml:space="preserve">
+    <value>Support the Project</value>
+  </data>
+  <data name="TitleBar.Discord" xml:space="preserve">
+    <value>Join the Discord community</value>
+  </data>
+</root>

--- a/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
+++ b/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
@@ -61,6 +61,7 @@ public partial class SettingsViewModel(
         new() { DisplayName = "日本語", Culture = new CultureInfo("ja-JP") },
         new() { DisplayName = "Polski", Culture = new CultureInfo("pl-PL") },
         new() { DisplayName = "Español", Culture = new CultureInfo("es-ES") },
+        new() { DisplayName = "Português (BR)", Culture = new CultureInfo("pt-BR") },
     ];
 
     public override async Task OnNavigatedToAsync()


### PR DESCRIPTION
## Description

Adds Portuguese (pt-BR) translations to the application interface.

Includes translated strings in `optimizerDuck/Resources/Languages/Translations.pt-BR.resx` and adjusts missing entries found by the review. There are no changes to behavior or logic; only i18n content.

## Type of change

- [ ] `feat:` — New optimization, customize setting, or app feature
- [ ] `fix:` — Bug fix
- [ ] `refactor:` — Code restructuring without behavior change
- [ ] `docs:` — Documentation
- [ ] `test:` — Adding or fixing tests
- [x] `i18n:` — Translation / localization update
- [ ] `chore:` — Build, deps, CI, tooling

## Screenshots (if UI changes)

<img width="1349" height="794" alt="image" src="https://github.com/user-attachments/assets/2021807e-a31a-47b0-a633-94723d4b344a" />

## Notes

No side effects expected; changes limited to .resx and `optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs`
