### PR TITLE
docs: integrate zdoc.app translations with existing language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
 **[Getting Started](https://optimizerduck.vercel.app/docs/guides/getting-started) | [How It Works](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-**English** | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md)
+<!-- Keep these links, translations synced daily. -->
+**English** | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [Deutsch](https://zdoc.app/de/itsfatduck/optimizerDuck) | [Español](https://zdoc.app/es/itsfatduck/optimizerDuck) | [français](https://zdoc.app/fr/itsfatduck/optimizerDuck) | [日本語](https://zdoc.app/ja/itsfatduck/optimizerDuck) | [한국어](https://zdoc.app/ko/itsfatduck/optimizerDuck) | [Português](https://zdoc.app/pt/itsfatduck/optimizerDuck) | [Русский](https://zdoc.app/ru/itsfatduck/optimizerDuck) | [中文](https://zdoc.app/zh/itsfatduck/optimizerDuck) | [Polski](README.pl-PL.md)
 
 <details>
 <summary>⭐ Star History</summary>


### PR DESCRIPTION
This PR integrates [zdoc.app](https://zdoc.app) translation links with the project's existing language switcher in the README header.

**What changed**

- Replaced project-maintained translation links with [zdoc.app](https://zdoc.app) for: Spanish, French, Japanese, Korean, Portuguese, Russian, Simplified Chinese
- Added [zdoc.app](https://zdoc.app) translations for languages the project doesn't maintain: **German**
- Preserved project-maintained translations for: **Vietnamese**, **Traditional Chinese** (zdoc.app has no separate `zh-TW`), **Polish** (zdoc.app doesn't expose these locales)

Translations are automatically synchronized and require no maintenance effort from project maintainers.

This change only affects README documentation and does not modify project code, dependencies, CI workflows, or repository settings.
