### PR TITLE
i18n: add German translation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ optimizerDuck.slnx                          # Solution file (.slnx format)
 │   └── Resources/                          # Images, embedded assets, localization
 │       ├── Embedded/                       # Power plans (optimizerDuck.pow), Icons (blank.ico)
 │       ├── Images/                         # Duck.png, GitHubLogo, DiscordLogo
-│       └── Languages/                      # Translations.resx + 11 locale variants
+│       └── Languages/                      # Translations.resx + 12 locale variants
 │
 └── optimizerDuck.Test/                     # xUnit v3 test project
     ├── Common/Helpers/
@@ -1078,6 +1078,7 @@ All user-facing strings live in `Resources/Languages/Translations.resx`. Use the
 | Language | File |
 |---|---|
 | English | `Translations.resx` (default) |
+| German | `Translations.de-DE.resx` |
 | Vietnamese | `Translations.vi-VN.resx` |
 | Spanish | `Translations.es-ES.resx` |
 | French | `Translations.fr-FR.resx` |
@@ -1090,7 +1091,7 @@ All user-facing strings live in `Resources/Languages/Translations.resx`. Use the
 | Turkish | `Translations.tr-TR.resx` |
 | Portuguese (Brazil) | `Translations.pt-BR.resx` |
 
-> **Note**: 11 locale variants total, plus English as the default fallback.
+> **Note**: 12 locale variants total, plus English as the default fallback.
 
 ### Adding a New Language
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Every star helps motivate future improvements.
 > | | Language | Native Name | Translator |
 > |------|----------|-------------|------------|
 > | 🇺🇸 | English (United States) | English | Primary & recommended |
+> | 🇩🇪 | German | Deutsch | Community contribution |
 > | 🇻🇳 | Vietnamese | Tiếng Việt | [itsfatduck](https://github.com/itsfatduck) |
 > | 🇹🇼 | Traditional Chinese | 正體中文 | [abc0922001](https://github.com/abc0922001) |
 > | 🇨🇳 | Simplified Chinese | 简体中文 | [wcxu21](https://github.com/wcxu21) |

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Every star helps motivate future improvements.
 > | | Language | Native Name | Translator |
 > |------|----------|-------------|------------|
 > | 🇺🇸 | English (United States) | English | Primary & recommended |
-> | 🇩🇪 | German | Deutsch | Community contribution |
 > | 🇻🇳 | Vietnamese | Tiếng Việt | [itsfatduck](https://github.com/itsfatduck) |
 > | 🇹🇼 | Traditional Chinese | 正體中文 | [abc0922001](https://github.com/abc0922001) |
 > | 🇨🇳 | Simplified Chinese | 简体中文 | [wcxu21](https://github.com/wcxu21) |
 > | 🇷🇺 | Russian | Русский | [Foodhead](https://github.com/Foodhead) |
 > | 🇫🇷 | French | Français | [Robocnop](https://github.com/Robocnop) |
+> | 🇩🇪 | German | Deutsch | [pixeldepartment](https://github.com/pixeldepartment) |
 > | 🇰🇷 | Korean | 한국어 | [klfnn](https://github.com/klfnn) |
 > | 🇪🇸 | Spanish | Español | [thexxtt](https://github.com/thexxtt) |
 > | 🇯🇵 | Japanese | 日本語 | [zerofrip](https://github.com/zerofrip) |

--- a/optimizerDuck.Test/Services/OptimizationServices/ServiceProcessServiceTests.cs
+++ b/optimizerDuck.Test/Services/OptimizationServices/ServiceProcessServiceTests.cs
@@ -208,7 +208,7 @@ public class ServiceProcessServiceTests
     [Fact]
     public async Task GetStartupTypeAsync_ExistingDemandService_ReturnsManual()
     {
-        var (result, notFound) = await ServiceProcessService.GetStartupTypeAsync("BITS");
+        var (result, notFound) = await ServiceProcessService.GetStartupTypeAsync("msiserver");
 
         Assert.False(notFound);
         Assert.NotNull(result);

--- a/optimizerDuck.Test/TestCulture.cs
+++ b/optimizerDuck.Test/TestCulture.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using optimizerDuck.Resources.Languages;
+
+namespace optimizerDuck.Test;
+
+internal static class TestCulture
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
+        Translations.Culture = culture;
+    }
+}

--- a/optimizerDuck/Resources/Languages/Translations.de-DE.resx
+++ b/optimizerDuck/Resources/Languages/Translations.de-DE.resx
@@ -1,0 +1,1845 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+        Microsoft ResX Schema 
+        
+        Version 2.0
+        
+        The primary goals of this format is to allow a simple XML format 
+        that is mostly human readable. The generation and parsing of the 
+        various data types are done through the TypeConverter classes 
+        associated with the data types.
+        
+        Example:
+        
+        ... ado.net/XML headers & schema ...
+        <resheader name="resmimetype">text/microsoft-resx</resheader>
+        <resheader name="version">2.0</resheader>
+        <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+        <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+        <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+        <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+        <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+            <value>[base64 mime encoded serialized .NET Framework object]</value>
+        </data>
+        <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+            <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+            <comment>This is a comment</comment>
+        </data>
+                    
+        There are any number of "resheader" rows that contain simple 
+        name/value pairs.
+        
+        Each data row contains a name, and value. The row also contains a 
+        type or mimetype. Type corresponds to a .NET class that support 
+        text/value conversion through the TypeConverter architecture. 
+        Classes that don't support this are serialized and stored with the 
+        mimetype set.
+        
+        The mimetype is used for serialized objects, and tells the 
+        ResXResourceReader how to depersist the object. This is currently not 
+        extensible. For a given mimetype the value must be set accordingly:
+        
+        Note - application/x-microsoft.net.object.binary.base64 is the format 
+        that the ResXResourceWriter will generate, however the reader can 
+        read any of the formats listed below.
+        
+        mimetype: application/x-microsoft.net.object.binary.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+                : and then encoded with base64 encoding.
+        
+        mimetype: application/x-microsoft.net.object.soap.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+                : and then encoded with base64 encoding.
+    
+        mimetype: application/x-microsoft.net.object.bytearray.base64
+        value   : The object must be serialized into a byte array 
+                : using a System.ComponentModel.TypeConverter
+                : and then encoded with base64 encoding.
+        -->
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root" xmlns="">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <data name="Dashboard.Header.Title" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="Sidebar.Dashboard" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="Sidebar.Settings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Cores" xml:space="preserve">
+    <value>{0} Kerne</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.DiskInfo" xml:space="preserve">
+    <value>{0} GB von {1} GB verwendet ({2} GB frei)</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Modules" xml:space="preserve">
+    <value>{0} Modul(e)</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Threads" xml:space="preserve">
+    <value>{0} Threads</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.System" xml:space="preserve">
+    <value>SYSTEM</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.Header" xml:space="preserve">
+    <value>Speicher</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Used" xml:space="preserve">
+    <value>{0} GB verwendet</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Available" xml:space="preserve">
+    <value>{0} GB verfügbar</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Loading" xml:space="preserve">
+    <value>Systeminformationen werden abgerufen...</value>
+  </data>
+  <data name="Sidebar.Optimize" xml:space="preserve">
+    <value>Optimieren</value>
+  </data>
+  <data name="Customize.Description" xml:space="preserve">
+    <value>Windows-Einstellungen und Präferenzen anpassen</value>
+  </data>
+  <data name="Customize.Preferences.Name" xml:space="preserve">
+    <value>Präferenzen</value>
+  </data>
+  <data name="Customize.Preferences.Description" xml:space="preserve">
+    <value>Visuelle und Interaktionseinstellungen anpassen</value>
+  </data>
+  <data name="Customize.Gaming.Name" xml:space="preserve">
+    <value>Gaming</value>
+  </data>
+  <data name="Customize.Gaming.Description" xml:space="preserve">
+    <value>Anzeige-, Eingabe- und Aufnahmeeinstellungen für Spiele</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Gpu.More" xml:space="preserve">
+    <value>+ {0} weitere GPU</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Title" xml:space="preserve">
+    <value>Discord-Community</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Description" xml:space="preserve">
+    <value>Tritt meiner Discord-Community bei, um Support zu erhalten oder mit mir zu spielen</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Title" xml:space="preserve">
+    <value>GitHub-Repository</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Description" xml:space="preserve">
+    <value>Mein Projekt auf GitHub ansehen, prüfen und dazu beitragen</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Title" xml:space="preserve">
+    <value>Beitragen</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Description" xml:space="preserve">
+    <value>Gib dem Repo auf GitHub einen Stern, teile es mit Freunden oder spende - jeder Beitrag hilft diesem Projekt zu wachsen!</value>
+  </data>
+  <data name="Service.Registry.Description.CreateKey" xml:space="preserve">
+    <value>Registrierungsschlüssel {0} erstellen</value>
+  </data>
+  <data name="Service.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>Registrierungsschlüssel {0} löschen</value>
+  </data>
+  <data name="Settings.LanguageChanged.Title" xml:space="preserve">
+    <value>Sprachänderung</value>
+  </data>
+  <data name="Settings.LanguageChanged.Description" xml:space="preserve">
+    <value>Du musst die Anwendung neu starten, um die neue Sprache zu übernehmen.</value>
+  </data>
+  <data name="Button.Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Settings.Header.Title" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="Settings.Appearance.Header" xml:space="preserve">
+    <value>Darstellung</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Title" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Description" xml:space="preserve">
+    <value>Wähle deine bevorzugte Sprache.</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Title" xml:space="preserve">
+    <value>Design</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Description" xml:space="preserve">
+    <value>Wähle dein bevorzugtes Design für die App.</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Light" xml:space="preserve">
+    <value>Hell</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Dark" xml:space="preserve">
+    <value>Dunkel</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.HighContrast" xml:space="preserve">
+    <value>Hoher Kontrast</value>
+  </data>
+  <data name="Common.AppliedSecondsAgo" xml:space="preserve">
+    <value>Vor {0} Sekunden angewendet</value>
+  </data>
+  <data name="Common.AppliedMinutesAgo" xml:space="preserve">
+    <value>Vor {0} Minuten angewendet</value>
+  </data>
+  <data name="Common.AppliedHoursAgo" xml:space="preserve">
+    <value>Vor {0} Stunden angewendet</value>
+  </data>
+  <data name="Common.AppliedDaysAgo" xml:space="preserve">
+    <value>Vor {0} Tagen angewendet</value>
+  </data>
+  <data name="Common.AppliedMonthsAgo" xml:space="preserve">
+    <value>Vor {0} Monaten angewendet</value>
+  </data>
+  <data name="Common.AppliedYearsAgo" xml:space="preserve">
+    <value>Vor {0} Jahren angewendet</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Safe" xml:space="preserve">
+    <value>Sicher</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Moderate" xml:space="preserve">
+    <value>Vorsicht</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Risky" xml:space="preserve">
+    <value>Experte</value>
+  </data>
+  <data name="OptimizationDetailsDialog.DetailedDescription" xml:space="preserve">
+    <value>Detaillierte Beschreibung</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.ShortDescription" xml:space="preserve">
+    <value>Setzt den Service-Host-Aufteilungsschwellenwert passend zum gesamten Arbeitsspeicher, sodass Windows Dienste zur besseren Stabilität in separate Prozesse isoliert.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DetectActivePlanFailed" xml:space="preserve">
+    <value>Der aktuell aktive Energiesparplan konnte nicht erkannt werden.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ImportFailed" xml:space="preserve">
+    <value>Der Energiesparplan von optimizerDuck konnte nicht importiert werden.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ActivateFailed" xml:space="preserve">
+    <value>Der Energiesparplan von optimizerDuck konnte nicht aktiviert werden.</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Help" xml:space="preserve">
+    <value>Dieser Wert gibt den Eingriffsgrad und die Sicherheit des Optimierungsvorgangs an. Sei vorsichtig und überlege sorgfältig, bevor du eine Optimierung anwendest.</value>
+  </data>
+  <data name="Optimizer.UI.Tags.System" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Ram" xml:space="preserve">
+    <value>RAM</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Disk" xml:space="preserve">
+    <value>Datenträger</value>
+  </data>
+  <data name="Optimizer.UI.Tags.NetworkRequired" xml:space="preserve">
+    <value>Netzwerkverbindung erforderlich</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Network" xml:space="preserve">
+    <value>Netzwerk</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Privacy" xml:space="preserve">
+    <value>Datenschutz</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Audio" xml:space="preserve">
+    <value>Audio</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Help" xml:space="preserve">
+    <value>Diese Tags zeigen an, welche Teile des Systems von der Optimierung betroffen sind.</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Nvidia" xml:space="preserve">
+    <value>NVIDIA</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Amd" xml:space="preserve">
+    <value>AMD</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Intel" xml:space="preserve">
+    <value>Intel</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Power" xml:space="preserve">
+    <value>Energie</value>
+  </data>
+  <data name="Revert.Error.InvalidData" xml:space="preserve">
+    <value>Ungültige Wiederherstellungsdaten für {0}: {1}</value>
+  </data>
+  <data name="Revert.Error.NoDataFound" xml:space="preserve">
+    <value>Keine Wiederherstellungsdaten für {0} gefunden.</value>
+  </data>
+  <data name="Optimization.Revert.Reverting" xml:space="preserve">
+    <value>Wird zurückgesetzt...</value>
+  </data>
+  <data name="Optimization.Revert.Success" xml:space="preserve">
+    <value>{0} erfolgreich zurückgesetzt!</value>
+  </data>
+  <data name="Optimization.Revert.Error.FailedWithSteps" xml:space="preserve">
+    <value>{0} mit {1} fehlgeschlagenen Schritt(en) zurückgesetzt.</value>
+  </data>
+  <data name="Revert.Error.RevertFailed" xml:space="preserve">
+    <value>Fehler beim Zurücksetzen von {0}: {1}</value>
+  </data>
+  <data name="Optimization.Revert.ExecutingStep" xml:space="preserve">
+    <value>Wiederherstellungsschritt wird ausgeführt: {0}/{1} ({2})</value>
+  </data>
+  <data name="Optimization.Revert.StepDescription" xml:space="preserve">
+    <value>Wiederherstellungsschritt #{0}</value>
+  </data>
+  <data name="Revert.Registry.Description.RestoreKey" xml:space="preserve">
+    <value>Registrierungsschlüssel wiederherstellen: {0}</value>
+  </data>
+  <data name="Revert.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>Registrierungsschlüssel löschen: {0}</value>
+  </data>
+  <data name="Revert.Registry.Description.RevertUnknown" xml:space="preserve">
+    <value>Registrierung zurücksetzen: {0}</value>
+  </data>
+  <data name="Revert.Error.FileNotFound" xml:space="preserve">
+    <value>Wiederherstellungsdatei nicht gefunden</value>
+  </data>
+  <data name="Revert.Error.FileEmpty" xml:space="preserve">
+    <value>Wiederherstellungsdatei ist leer</value>
+  </data>
+  <data name="Revert.Error.ReadFailed" xml:space="preserve">
+    <value>Wiederherstellungsdaten konnten nicht gelesen werden: {0}</value>
+  </data>
+  <data name="Revert.Error.InvalidJson" xml:space="preserve">
+    <value>Ungültige Wiederherstellungsdaten</value>
+  </data>
+  <data name="Revert.Error.InvalidJsonFormat" xml:space="preserve">
+    <value>Ungültiges JSON-Format: {0}</value>
+  </data>
+  <data name="Revert.Error.NoSteps" xml:space="preserve">
+    <value>Keine Wiederherstellungsschritte gefunden.</value>
+  </data>
+  <data name="Revert.Error.InvalidSteps" xml:space="preserve">
+    <value>Ungültige Wiederherstellungsschritte: {0}</value>
+  </data>
+  <data name="Revert.Error.StepFailed" xml:space="preserve">
+    <value>Wiederherstellungsschritt fehlgeschlagen</value>
+  </data>
+  <data name="Revert.UsbPower.Description" xml:space="preserve">
+    <value>Energiezustände für selektives USB-Energiesparen wiederherstellen</value>
+  </data>
+  <data name="Service.Registry.Error.BackupTruncated" xml:space="preserve">
+    <value>Registrierungsunterstruktur ist zu groß für eine sichere Sicherung; Löschen für {0} abgebrochen</value>
+  </data>
+  <data name="Revert.Error.OptimizationIdMismatch" xml:space="preserve">
+    <value>OptimizationId stimmt nicht überein.</value>
+  </data>
+  <data name="Optimization.Apply.Processing" xml:space="preserve">
+    <value>Änderungen werden angewendet...</value>
+  </data>
+  <data name="Optimization.Apply.Completed" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
+  <data name="Optimization.Apply.Success" xml:space="preserve">
+    <value>{0} erfolgreich angewendet.</value>
+  </data>
+  <data name="Optimization.Apply.Error.FailedWithSteps" xml:space="preserve">
+    <value>{0} mit {1} fehlgeschlagenen Schritt(en) angewendet.</value>
+  </data>
+  <data name="Optimization.Apply.Error.Failed" xml:space="preserve">
+    <value>Fehler beim Anwenden von {0}.</value>
+  </data>
+  <data name="Optimization.Apply.Error.Unknown" xml:space="preserve">
+    <value>Unbekanntes Ergebnis für {0}.</value>
+  </data>
+  <data name="Service.Common.Error.AccessDenied" xml:space="preserve">
+    <value>Zugriff verweigert</value>
+  </data>
+  <data name="Service.Registry.Error.AccessDeniedProtectedHive" xml:space="preserve">
+    <value>Zugriff verweigert (geschützter Hive)</value>
+  </data>
+  <data name="Service.Registry.Error.UnauthorizedAccess" xml:space="preserve">
+    <value>Unautorisierter Zugriff</value>
+  </data>
+  <data name="Service.Registry.Error.CreateOrOpenSubkeyFailed" xml:space="preserve">
+    <value>Unterschlüssel konnte nicht erstellt/geöffnet werden</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedWrite" xml:space="preserve">
+    <value>Zugriff beim Schreiben von {0}:{1} verweigert</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDelete" xml:space="preserve">
+    <value>Zugriff beim Löschen von {0}:{1} verweigert</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedCreateKey" xml:space="preserve">
+    <value>Zugriff beim Erstellen von {0} verweigert</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDeleteKeyTree" xml:space="preserve">
+    <value>Zugriff beim Löschen der Schlüsselstruktur {0} verweigert</value>
+  </data>
+  <data name="Service.Service.Error.NotFound" xml:space="preserve">
+    <value>Dienst nicht gefunden</value>
+  </data>
+  <data name="Service.Service.Info.SkippedNotFound" xml:space="preserve">
+    <value>Dienst "{0}" nicht gefunden (übersprungen)</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartupTypeFailed" xml:space="preserve">
+    <value>Starttyp für Dienst konnte nicht geändert werden</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartModeFailedWithCode" xml:space="preserve">
+    <value>ChangeStartMode fehlgeschlagen (Code: {0})</value>
+  </data>
+  <data name="Service.Service.Error.ExceptionOccurred" xml:space="preserve">
+    <value>Dienst "{0}" konnte nicht geändert werden: {1}</value>
+  </data>
+  <data name="Service.Shell.Error.ExitCode" xml:space="preserve">
+    <value>Exitcode {0}</value>
+  </data>
+  <data name="Service.Shell.Error.TimedOut" xml:space="preserve">
+    <value>Zeitüberschreitung</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Title" xml:space="preserve">
+    <value>Wiederherstellungsdatei</value>
+  </data>
+  <data name="OptimizationResultDialog.Header" xml:space="preserve">
+    <value>{0} fehlgeschlagene Schritte</value>
+  </data>
+  <data name="OptimizationResultDialog.Description" xml:space="preserve">
+    <value>Einige Schritte wurden nicht erfolgreich abgeschlossen. Du kannst nur die fehlgeschlagenen Schritte erneut versuchen.</value>
+  </data>
+  <data name="OptimizationResultDialog.Details" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="Button.Retry" xml:space="preserve">
+    <value>Erneut versuchen</value>
+  </data>
+  <data name="Settings.About.Duck.Description" xml:space="preserve">
+    <value>Aktuelle Version: {0}</value>
+  </data>
+  <data name="Settings.Advanced.Header" xml:space="preserve">
+    <value>Erweitert</value>
+  </data>
+  <data name="Settings.Optimize.Header" xml:space="preserve">
+    <value>Optimieren</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Title" xml:space="preserve">
+    <value>Shell-Dienst-Zeitlimit</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Description" xml:space="preserve">
+    <value>Zeitlimit für jede Shell-Befehlsausführung (Millisekunden).</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Title" xml:space="preserve">
+    <value>Downloads löschen</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Description" xml:space="preserve">
+    <value>Alle während der Optimierung heruntergeladenen Dateien löschen.</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Title" xml:space="preserve">
+    <value>Alle Wiederherstellungsdaten löschen</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Description" xml:space="preserve">
+    <value>Alle Rollback-Daten aus Optimierungen löschen.</value>
+  </data>
+  <data name="Button.Clear" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Title" xml:space="preserve">
+    <value>Stammverzeichnis öffnen</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Description" xml:space="preserve">
+    <value>Stammverzeichnis der Anwendung öffnen, in dem alle notwendigen Dateien gespeichert sind.</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Title" xml:space="preserve">
+    <value>Sanftes Scrollen</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Description" xml:space="preserve">
+    <value>Sanfte Scrollanimation für ein flüssigeres Scrollen aktivieren. Deaktiviere sie, wenn Verzögerungen auftreten.</value>
+  </data>
+  <data name="Button.Open" xml:space="preserve">
+    <value>Öffnen</value>
+  </data>
+  <data name="Settings.About.Header" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="Dialog.AreYouSure.Title" xml:space="preserve">
+    <value>Möchtest du wirklich fortfahren?</value>
+  </data>
+  <data name="Settings.ClearDownloads.Description" xml:space="preserve">
+    <value>Du bist dabei, alle während der Optimierung heruntergeladenen Dateien zu löschen. Diese Aktion ist dauerhaft und kann nicht rückgängig gemacht werden. Stelle sicher, dass du dir sicher bist, bevor du fortfährst.</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="Button.Skip" xml:space="preserve">
+    <value>Überspringen</value>
+  </data>
+  <data name="Settings.ClearRevertData.Description" xml:space="preserve">
+    <value>Du bist dabei, alle nach der Optimierung erzeugten Rollback-Daten zu löschen. Danach kannst du den Zustand vor der Optimierung nicht mehr wiederherstellen. Überlege daher sorgfältig, bevor du bestätigst.</value>
+  </data>
+  <data name="ProcessingOptimizationDialog.Warning.DontCloseAppOrRestart" xml:space="preserve">
+    <value>Bitte schließe die App nicht und starte nicht neu, während Änderungen angewendet oder zurückgesetzt werden.</value>
+  </data>
+  <data name="Common.AppliedJustNow" xml:space="preserve">
+    <value>Gerade angewendet</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Error.Title" xml:space="preserve">
+      <value>Optimierung konnte nicht vollständig angewendet werden</value>
+    </data>
+  <data name="Optimization.Revert.Snackbar.Error.Title" xml:space="preserve">
+    <value>Optimierung konnte nicht zurückgesetzt werden</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Success.Title" xml:space="preserve">
+    <value>Optimierung erfolgreich angewendet</value>
+  </data>
+  <data name="Optimization.Revert.Snackbar.Success.Title" xml:space="preserve">
+    <value>Optimierung erfolgreich zurückgesetzt</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Title" xml:space="preserve">
+    <value>Optimierung konnte nicht umgeschaltet werden</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Message" xml:space="preserve">
+    <value>Ein Fehler ist aufgetreten: {0}</value>
+  </data>
+  <data name="Optimization.Retry.Processing" xml:space="preserve">
+    <value>Fehlgeschlagene Schritte werden erneut versucht...</value>
+  </data>
+  <data name="Optimization.RetryStep.Processing" xml:space="preserve">
+    <value>{0}-Schritt wird erneut versucht ({1}/{2} Schritte)</value>
+  </data>
+  <data name="Optimization.Revert.Error.Failed" xml:space="preserve">
+    <value>Fehler beim Zurücksetzen von {0}.</value>
+  </data>
+  <data name="Dashboard.Header.Menu.Refresh" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="Dashboard.Header.Menu.RunTaskManager" xml:space="preserve">
+    <value>Task-Manager</value>
+  </data>
+  <data name="Common.Unknown" xml:space="preserve">
+    <value>Unbekannt</value>
+  </data>
+  <data name="Common.Recommendation.On" xml:space="preserve">
+    <value>Empfohlen</value>
+  </data>
+  <data name="Common.Recommendation.Off" xml:space="preserve">
+    <value>Nicht empfohlen</value>
+  </data>
+  <data name="Common.Recommendation.Experimental" xml:space="preserve">
+    <value>Experimentell</value>
+  </data>
+  <data name="Common.Recommendation.Depends" xml:space="preserve">
+    <value>Abhängig</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Security" xml:space="preserve">
+    <value>Sicherheit</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Performance" xml:space="preserve">
+    <value>Leistung</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Latency" xml:space="preserve">
+    <value>Latenz</value>
+  </data>
+  <data name="Optimizer.Performance" xml:space="preserve">
+    <value>Leistung</value>
+  </data>
+  <data name="Optimizer.PowerManagement" xml:space="preserve">
+    <value>Energieverwaltung</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy" xml:space="preserve">
+    <value>Sicherheit &amp; Datenschutz</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices" xml:space="preserve">
+    <value>Bloatware &amp; Dienste</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.Name" xml:space="preserve">
+    <value>Hintergrund-Apps deaktivieren</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.ShortDescription" xml:space="preserve">
+    <value>Verhindert, dass inaktive Anwendungen im Hintergrund laufen, um RAM freizugeben und CPU-Overhead zu reduzieren.</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Name" xml:space="preserve">
+    <value>Dienstisolation optimieren</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Error.InvalidRAM" xml:space="preserve">
+    <value>Ungültiger RAM: {0}</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.Name" xml:space="preserve">
+    <value>Aktive Anwendungen priorisieren</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.ShortDescription" xml:space="preserve">
+    <value>Weist der aktuell verwendeten Anwendung mehr CPU-Ressourcen zu, damit sie schneller und reaktionsfreudiger läuft.</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.Name" xml:space="preserve">
+    <value>Multimedia-Scheduler optimieren</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
+    <value>Konfiguriert den Multimedia Class Scheduler Service (MMCSS) für Gaming und niedrige Latenz, indem Multimedia-Workloads priorisiert und Netzwerkdrosselung deaktiviert werden.</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
+    <value>Tastaturwiederholung optimieren</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.ShortDescription" xml:space="preserve">
+    <value>Setzt die schnellste Tastatur-Wiederholverzögerung und Wiederholrate für reaktionsschnelleres Tippen und gedrückte Tasten.</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.Name" xml:space="preserve">
+    <value>Bedienhilfen-Tastenkürzel deaktivieren</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Tastenkürzel für Einrast-, Filter- und Umschalttasten, um versehentliche Pop-ups beim Spielen und Tippen zu verhindern.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.Name" xml:space="preserve">
+    <value>Ruhezustand &amp; Schnellstart deaktivieren</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Ruhezustand und Schnellstart, um Speicherplatz zurückzugewinnen und beim Start eine vollständige Hardwareinitialisierung sicherzustellen.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.Name" xml:space="preserve">
+    <value>USB-Energiesparen deaktivieren</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.ShortDescription" xml:space="preserve">
+    <value>Verhindert, dass Windows USB-Ports abschaltet, und beseitigt Aufwachverzögerungen bei Mäusen, Tastaturen und anderen Peripheriegeräten.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Name" xml:space="preserve">
+    <value>Optimierten Energiesparplan anwenden</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.ShortDescription" xml:space="preserve">
+    <value>Installiert einen benutzerdefinierten, leistungsorientierten Energiesparplan, damit dein System immer mit maximaler Geschwindigkeit läuft. Warnung: Auf manchen Systemen kann der Task-Manager fälschlicherweise 100 % CPU-Auslastung anzeigen; die tatsächliche CPU-Last ist nicht betroffen.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Progress.Importing" xml:space="preserve">
+    <value>Energiesparplan wird importiert und aktiviert...</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.Name" xml:space="preserve">
+    <value>Systemleistungsdrosselung deaktivieren</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.ShortDescription" xml:space="preserve">
+    <value>Verhindert, dass Windows die CPU-Leistung begrenzt (Power Throttling), damit aktive Aufgaben maximale Leistung behalten.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Name" xml:space="preserve">
+    <value>Datensammlung (Telemetrie) deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Windows-Telemetrie und Nutzungsverfolgungsdienste, um deine Privatsphäre zu verbessern und Hintergrundaktivität zu reduzieren.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.EditRegistry" xml:space="preserve">
+    <value>Richtlinien- und Registrierungsänderungen werden angewendet...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableServices" xml:space="preserve">
+    <value>Telemetriedienste werden deaktiviert...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableTasks" xml:space="preserve">
+    <value>Geplante Telemetrieaufgaben werden deaktiviert...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.Name" xml:space="preserve">
+    <value>Fehlerberichterstattung deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Windows-Fehlerberichterstattung und Programmkompatibilitäts-Assistent-Dienste.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.Name" xml:space="preserve">
+    <value>Werbung und Vorschläge deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert personalisierte Werbung, Windows-Consumerfeatures und Systemvorschläge.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.Name" xml:space="preserve">
+    <value>Aktivitätsverlauf deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.ShortDescription" xml:space="preserve">
+    <value>Verhindert, dass Windows deinen Aktivitätsverlauf sammelt und synchronisiert.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.Name" xml:space="preserve">
+    <value>Standort und Sensoren deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Standortverfolgung, Systemsensoren und Offlinekarten-Updates.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.Name" xml:space="preserve">
+    <value>Hintergrundprotokollierung deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.ShortDescription" xml:space="preserve">
+    <value>Stoppt nicht essenzielle Systemereignisprotokollierung, um fortlaufende Datenträgeraktivität und CPU-Zyklen zu reduzieren.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.Name" xml:space="preserve">
+    <value>Cortana &amp; Websuche deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert den Cortana-Sprachassistenten und entfernt Bing-Webresultate aus der Windows-Suchleiste.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.Name" xml:space="preserve">
+    <value>Windows Copilot deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.ShortDescription" xml:space="preserve">
+    <value>Entfernt den KI-Assistenten Copilot aus Taskleiste und System-Shell, um Arbeitsspeicher und Bildschirmplatz freizugeben.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.Name" xml:space="preserve">
+    <value>Cloud-Inhaltsbereitstellung deaktivieren</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert von der Cloud bereitgestellte Windows-Inhalte, einschließlich Systemtipps, Spotlight-Vorschlägen und automatischer Bereitstellung von Consumerfeatures.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.Name" xml:space="preserve">
+    <value>Vorinstallierte Bloatware blockieren</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.ShortDescription" xml:space="preserve">
+    <value>Verhindert, dass Windows unerwünschte Drittanbieter-Apps und beworbene Software automatisch erneut installiert.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Name" xml:space="preserve">
+    <value>Systemdienste optimieren</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.ShortDescription" xml:space="preserve">
+    <value>Passt nicht essenzielle Hintergrunddienste an, um Ressourcen freizugeben und notwendige Windows-Funktionen beizubehalten.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Progress.ChangeServiceStartupType" xml:space="preserve">
+    <value>Starttyp für {0} wird auf {1} gesetzt...</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Display" xml:space="preserve">
+    <value>Anzeige</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Visual" xml:space="preserve">
+    <value>Visuell</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Windows10Only" xml:space="preserve">
+    <value>Nur Windows 10</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Windows11Only" xml:space="preserve">
+    <value>Nur Windows 11</value>
+  </data>
+  <data name="Optimizer.Gpu" xml:space="preserve">
+    <value>GPU</value>
+  </data>
+  <data name="Optimizer.UserExperience" xml:space="preserve">
+    <value>Benutzererfahrung</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.Name" xml:space="preserve">
+    <value>Explorer &amp; Menüs beschleunigen</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
+    <value>Setzt StartupDelayInMSec=0 und MenuShowDelay=0, um Explorer-Startverzögerungen zu beseitigen und Menü-Hoververzögerungen auf ein Minimum zu reduzieren.</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.Name" xml:space="preserve">
+    <value>Websuche im Startmenü deaktivieren</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert die Websuche im Windows-Startmenü, damit lokale Suchergebnisse schneller geladen werden.</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.Name" xml:space="preserve">
+    <value>Visuelle Effekte deaktivieren</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.ShortDescription" xml:space="preserve">
+    <value>Deaktiviert Taskleistenanimationen, ListView-Schatten, Fenstertransparenz und Aero Peek, um GPU/CPU-Ressourcen für bessere Leistung freizugeben.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.Name" xml:space="preserve">
+    <value>AMD ULPS deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.ShortDescription" xml:space="preserve">
+    <value>Setzt EnableULPS=0 in der AMD-GPU-Registry, um Aufwachverzögerungen durch den Ultra Low Power State und Multi-Monitor-Probleme zu verhindern. Reduziert das Energiesparen im Leerlauf.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.Name" xml:space="preserve">
+    <value>AMD Power Gating deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.ShortDescription" xml:space="preserve">
+    <value>Setzt DisablePowerGating=1, PP_GPUPowerDownEnabled=0 und DisableDynamicPstate=1, um Wechsel der AMD-GPU-Energiezustände zu verhindern. Hält konstante Taktraten auf Kosten höherer Leerlaufleistung.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.Name" xml:space="preserve">
+    <value>AMD Video Clock Gating deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.ShortDescription" xml:space="preserve">
+    <value>Setzt DisableVCEPowerGating=1, DisableVceClockGating=1 und EnableUvdClockGating=0 für AMD-Videoengines (VCE/UVD), um die Encode/Decode-Stabilität zu verbessern. Erhöht den Stromverbrauch bei Videowiedergabe.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.Name" xml:space="preserve">
+    <value>AMD ASPM deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.ShortDescription" xml:space="preserve">
+    <value>Setzt EnableAspmL0s=0 und EnableAspmL1=0, um Active State Power Management bei AMD-GPUs zu deaktivieren und PCIe-Buslatenz zu reduzieren. Erhöht die Leistungsaufnahme des Slots.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.Name" xml:space="preserve">
+    <value>NVIDIA Dynamic P-State deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.ShortDescription" xml:space="preserve">
+    <value>Setzt DisableDynamicPstate=1, um die NVIDIA-GPU in einem festen Leistungszustand zu halten und Taktschwankungen zu verhindern. Erhöht den Stromverbrauch im Leerlauf.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.Name" xml:space="preserve">
+    <value>NVIDIA Async P-States deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.ShortDescription" xml:space="preserve">
+    <value>Setzt DisableASyncPstates=1, um asynchrone NVIDIA-Energiezustandswechsel zu verhindern und deterministische Leistung für VR-/Echtzeit-Apps zu bieten.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.Name" xml:space="preserve">
+    <value>Intel Async Flips deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.ShortDescription" xml:space="preserve">
+    <value>Setzt Display1_DisableAsyncFlips=1, um synchrone Buffer-Flips auf Intel-iGPUs zu erzwingen und Eingabe-bis-Anzeige-Latenz sowie Screen Tearing zu reduzieren.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.Name" xml:space="preserve">
+    <value>Intel Adaptive V-Sync deaktivieren</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.ShortDescription" xml:space="preserve">
+    <value>Setzt AdaptiveVsyncEnable=0, um Intels adaptives V-Sync zu deaktivieren, das sich dynamisch an die Bildrate anpasst, und stattdessen festes V-Sync für stabiles Timing zu verwenden.</value>
+  </data>
+  <data name="Customize.Preferences.Section.Taskbar" xml:space="preserve">
+    <value>Taskleiste</value>
+  </data>
+  <data name="Customize.Preferences.Section.Appearance" xml:space="preserve">
+    <value>Darstellung</value>
+  </data>
+  <data name="Customize.Preferences.Section.Explorer" xml:space="preserve">
+    <value>Explorer</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Name" xml:space="preserve">
+    <value>Taskleisten-Widgets</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Description" xml:space="preserve">
+    <value>Steuert die Sichtbarkeit der Widgets-Schaltfläche in der Taskleiste.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren von Widgets entfernt den Hintergrund-Webdienst, der Nachrichten und Wetter abruft, und reduziert Netzwerk- und Speichernutzung im Leerlauf.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Name" xml:space="preserve">
+    <value>Taskleistenausrichtung</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Description" xml:space="preserve">
+    <value>Wechselt die Ausrichtung der Taskleiste zwischen Zentriert und Links.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Center" xml:space="preserve">
+    <value>Zentriert</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Left" xml:space="preserve">
+    <value>Links</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Name" xml:space="preserve">
+    <value>Explorer-Kompaktmodus</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Description" xml:space="preserve">
+    <value>Verringert den Abstand zwischen Elementen im Datei-Explorer für eine dichtere Ansicht.</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Name" xml:space="preserve">
+    <value>Snap-Layouts-Flyout</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Description" xml:space="preserve">
+    <value>Steuert das Snap-Layouts-Menü, das beim Bewegen über die Maximieren-Schaltfläche angezeigt wird.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Name" xml:space="preserve">
+    <value>Explorer-Elementkontrollkästchen</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Description" xml:space="preserve">
+    <value>Zeigt Kontrollkästchen beim Auswählen von Elementen im Datei-Explorer an.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Name" xml:space="preserve">
+    <value>Taskansicht-Schaltfläche in der Taskleiste</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Description" xml:space="preserve">
+    <value>Steuert die Sichtbarkeit der Taskansicht-Schaltfläche in der Taskleiste.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Name" xml:space="preserve">
+    <value>"Task beenden" in der Taskleiste</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Description" xml:space="preserve">
+    <value>Fügt dem Rechtsklickmenü der Taskleiste eine Option "Task beenden" hinzu, um Prozesse schnell zu beenden.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Recommendation.Reason" xml:space="preserve">
+    <value>"Task beenden" in der Taskleiste lässt dich eingefrorene Apps sofort beenden, ohne den Task-Manager zu öffnen.</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Name" xml:space="preserve">
+    <value>Dunkelmodus</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Description" xml:space="preserve">
+    <value>Dunkelmodus für System-Apps, Einstellungen und Shell-Elemente.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Name" xml:space="preserve">
+    <value>Explorer-Synchronisierungsbenachrichtigungen</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Description" xml:space="preserve">
+    <value>Steuert OneDrive- und Cloud-Sync-Anbieterbenachrichtigungen im Datei-Explorer.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren von Synchronisierungsbenachrichtigungen verhindert, dass OneDrive-Pop-ups das Durchsuchen von Dateien im Explorer unterbrechen.</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Name" xml:space="preserve">
+    <value>Systemvorschläge</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Description" xml:space="preserve">
+    <value>Steuert Windows-Tipps und App-Vorschläge in den Einstellungen.</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren von Systemvorschlägen verhindert, dass Windows Apps und Einstellungen empfiehlt, die du nicht angefordert hast.</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Name" xml:space="preserve">
+    <value>Toast-Benachrichtigungen</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Description" xml:space="preserve">
+    <value>Steuert Toast-Popup-Benachrichtigungen und Sperrbildschirmbenachrichtigungen.</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Name" xml:space="preserve">
+    <value>Dateierweiterungen anzeigen</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Description" xml:space="preserve">
+    <value>Zeigt Dateierweiterungen (z. B. .txt, .exe) im Datei-Explorer an.</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Recommendation.Reason" xml:space="preserve">
+    <value>Das Anzeigen von Dateierweiterungen erleichtert das Erkennen verdächtiger Dateitypen und verhindert, dass Malware sich hinter falschen Symbolen versteckt.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Name" xml:space="preserve">
+    <value>Versteckte Dateien anzeigen</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Description" xml:space="preserve">
+    <value>Zeigt versteckte Dateien und Ordner im Datei-Explorer an.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Recommendation.Reason" xml:space="preserve">
+    <value>Versteckte Dateien enthalten System- und Konfigurationsdaten, die du möglicherweise verwalten musst; ihre Anzeige gibt dir vollständige Sicht auf dein System.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Name" xml:space="preserve">
+    <value>Zwischenablageverlauf</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Description" xml:space="preserve">
+    <value>Zwischenablageverlauf für mehrere kopierte Elemente, erreichbar mit Win+V.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Recommendation.Reason" xml:space="preserve">
+    <value>Der Zwischenablageverlauf lässt dich mehrere frühere Kopien mit Win+V abrufen und beschleunigt wiederholte Copy-Paste-Abläufe.</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Name" xml:space="preserve">
+    <value>Fenster schütteln</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Description" xml:space="preserve">
+    <value>Fenster schütteln, um alle anderen geöffneten Fenster zu minimieren.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Name" xml:space="preserve">
+    <value>Klassisches Kontextmenü</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Description" xml:space="preserve">
+    <value>Kontextmenü im Windows-10-Stil unter Windows 11.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Recommendation.Reason" xml:space="preserve">
+    <value>Das klassische Menü zeigt alle Optionen sofort, ohne den zusätzlichen Klick zum Erweitern des kompakten Windows-11-Menüs.</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Name" xml:space="preserve">
+    <value>Sekunden in der Systemuhr</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Description" xml:space="preserve">
+    <value>Zeigt Sekunden in der Taskleistenuhr an.</value>
+  </data>
+  <data name="Customize.Gaming.Section.GameSettings" xml:space="preserve">
+    <value>Spieleinstellungen</value>
+  </data>
+  <data name="Customize.Gaming.Section.Input" xml:space="preserve">
+    <value>Eingabe</value>
+  </data>
+  <data name="Customize.Gaming.Section.Display" xml:space="preserve">
+    <value>Anzeige</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Name" xml:space="preserve">
+    <value>Spielmodus</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Description" xml:space="preserve">
+    <value>Windows-Spielmodus für Spielprozesse und Windows-Update-Verhalten.</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Recommendation.Reason" xml:space="preserve">
+    <value>Der Spielmodus priorisiert Spielprozesse automatisch und unterbricht Windows-Update-Benachrichtigungen während des Spielens für flüssigere Leistung.</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Name" xml:space="preserve">
+    <value>Xbox Game Bar</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Description" xml:space="preserve">
+    <value>Steuert Xbox-Game-Bar-Overlays, Startfenster und zugehörige Hintergrundfunktionen.</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren der Game Bar gibt Systemressourcen frei und verhindert, dass Hintergrund-Overlays deine Spiele stören.</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Name" xml:space="preserve">
+    <value>Hintergrundaufnahme (DVR)</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Description" xml:space="preserve">
+    <value>Steuert automatische Hintergrund-Spielaufnahmen (Game DVR) und App-Aufzeichnung.</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren der Hintergrundaufnahme verhindert, dass DVR Gameplay unbemerkt aufzeichnet, und spart CPU- und Schreibzyklen.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Name" xml:space="preserve">
+    <value>Mausbeschleunigung</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Description" xml:space="preserve">
+    <value>Windows-Mausbeschleunigungseinstellung für Cursorbewegungen.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren der Beschleunigung gibt dir rohe, lineare Mauseingaben für bessere Zielpräzision und konsistentes Muskelgedächtnis.</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Name" xml:space="preserve">
+    <value>Vollbildoptimierungen</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Description" xml:space="preserve">
+    <value>Windows-DWM-basierte Vollbildoptimierungseinstellung.</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Recommendation.Reason" xml:space="preserve">
+    <value>Deaktiviere sie, wenn du im Spiel Ruckler, Eingabeverzögerungen oder schwarze Bildschirme bemerkst (besonders in kompetitiven Shootern).</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Name" xml:space="preserve">
+    <value>Hardwarebeschleunigte GPU-Planung</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Description" xml:space="preserve">
+    <value>GPU-Videospeicher-Planungsmodus. Erfordert einen kompatiblen GPU-Treiber.</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
+    <value>GPU-Planung verlagert Frame-Verwaltung von der CPU auf die GPU, reduziert Anzeigelatenz und verbessert Frame-Pacing.</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
+    <value>NICHT ändern, außer du weißt genau, was du tust</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DownloadFailed" xml:space="preserve">
+    <value>Der Energiesparplan von optimizerDuck konnte nicht heruntergeladen werden.</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Title" xml:space="preserve">
+    <value>Danksagungen</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Description" xml:space="preserve">
+    <value>optimizerDuck wird durch folgende Open-Source-Software und Ressourcen ermöglicht.</value>
+  </data>
+  <data name="RestorePoint.Title" xml:space="preserve">
+    <value>Systemwiederherstellung</value>
+  </data>
+  <data name="RestorePointDialog.Description" xml:space="preserve">
+    <value>Mit einem Wiederherstellungspunkt kannst du dein System auf einen früheren Zustand zurücksetzen.
+Das ist eine Sicherheitsmaßnahme zum Schutz deines Windows vor dem Anwenden von Änderungen.</value>
+  </data>
+  <data name="RestorePointDialog.Help" xml:space="preserve">
+    <value>Die Anwendung aktiviert automatisch die Systemwiederherstellung und erstellt einen Prüfpunkt namens "optimizerDuck...".
+So kannst du jederzeit zurückgehen, falls etwas schiefgeht.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Title" xml:space="preserve">
+    <value>Systemwiederherstellung konnte nicht erstellt oder aktiviert werden.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Message" xml:space="preserve">
+    <value>Beim Erstellen oder Aktivieren der Systemwiederherstellung ist ein Fehler aufgetreten. Bitte versuche, sie manuell zu erstellen.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Warning.LimitReached" xml:space="preserve">
+    <value>Innerhalb der letzten 24 Stunden wurde bereits ein Wiederherstellungspunkt erstellt.</value>
+  </data>
+  <data name="RestorePoint.Progress.Creating" xml:space="preserve">
+    <value>Wiederherstellungspunkt wird erstellt...</value>
+  </data>
+  <data name="RestorePoint.Progress.Enabling" xml:space="preserve">
+    <value>Systemwiederherstellung wird aktiviert...</value>
+  </data>
+  <data name="RestorePoint.Progress.Retrying" xml:space="preserve">
+    <value>Erstellung des Wiederherstellungspunkts wird erneut versucht...</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Title" xml:space="preserve">
+    <value>Wiederherstellungspunkt erfolgreich erstellt</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Message" xml:space="preserve">
+    <value>Ein Wiederherstellungspunkt wurde mit dem Namen {0} erstellt.</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Title" xml:space="preserve">
+    <value>Pfad konnte nicht geöffnet werden</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Message" xml:space="preserve">
+    <value>Beim Öffnen des Pfads ist ein Fehler aufgetreten. Bitte prüfe das Protokoll.</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Message" xml:space="preserve">
+    <value>Beim Öffnen des Ordners oder der Datei ist ein Fehler aufgetreten. Bitte prüfe das Protokoll.</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Title" xml:space="preserve">
+    <value>Ordner oder Datei konnte nicht geöffnet werden</value>
+  </data>
+  <data name="Button.ViewLatestRelease" xml:space="preserve">
+    <value>Neueste Version anzeigen</value>
+  </data>
+  <data name="BloatwareDialog.Title" xml:space="preserve">
+    <value>{0} AppX-Paket(e) werden entfernt</value>
+  </data>
+  <data name="BloatwareDialog.Removing" xml:space="preserve">
+    <value>{0} wird entfernt ({1}/{2})</value>
+  </data>
+  <data name="Bloatware.Header.Title" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="Bloatware.Menu.Remove" xml:space="preserve">
+    <value>Entfernen ({0})</value>
+  </data>
+  <data name="Bloatware.Menu.Refresh" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="Bloatware.Empty.Title" xml:space="preserve">
+    <value>Keine unnötigen Apps gefunden ¯\_(ツ)_/¯</value>
+  </data>
+  <data name="Bloatware.Empty.Description" xml:space="preserve">
+    <value>optimizerDuck hat keine entfernbaren AppX-Pakete gefunden. Hier ist alles leer...</value>
+  </data>
+  <data name="Bloatware.Loading" xml:space="preserve">
+    <value>Entfernbare Apps werden gesucht...</value>
+  </data>
+  <data name="Bloatware.Loading.Hint" xml:space="preserve">
+    <value>Dies kann einen Moment dauern, während die Anwendung installierte Pakete scannt.</value>
+  </data>
+  <data name="Sidebar.Bloatware" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Title" xml:space="preserve">
+    <value>{0} App(s) entfernen?</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Message" xml:space="preserve">
+    <value>Du bist dabei, Folgendes zu entfernen: {0}</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Description" xml:space="preserve">
+    <value>Prüfe die ausgewählten Apps vor dem Entfernen. Fahre nur fort, wenn du sicher bist.</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.SelectedList" xml:space="preserve">
+    <value>Ausgewählte Anwendungen</value>
+  </data>
+  <data name="Settings.Bloatware.Header" xml:space="preserve">
+    <value>Bloatware</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Title" xml:space="preserve">
+    <value>Bereitgestellte Pakete entfernen</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Description" xml:space="preserve">
+    <value>Entfernt beim Entfernen installierter AppX-Pakete auch die zugehörigen bereitgestellten Pakete, um automatische Neuinstallation für neue Benutzer zu verhindern.</value>
+  </data>
+  <data name="Dashboard.UpdateInfoBar.Message" xml:space="preserve">
+    <value>optimizerDuck (v{0}) ist verfügbar!
+Aktualisiere jetzt, um die neuesten Funktionen, Verbesserungen und Fehlerbehebungen zu nutzen.</value>
+  </data>
+  <data name="Common.Search.Placeholder" xml:space="preserve">
+    <value>Suchen...</value>
+  </data>
+  <data name="Common.Filter.All" xml:space="preserve">
+    <value>Alle</value>
+  </data>
+  <data name="Common.SortBy.Default" xml:space="preserve">
+    <value>Standard</value>
+  </data>
+  <data name="Common.SortBy.Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Common.SortBy.Risk" xml:space="preserve">
+    <value>Risiko</value>
+  </data>
+  <data name="Common.SortBy.Publisher" xml:space="preserve">
+    <value>Herausgeber</value>
+  </data>
+  <data name="Common.SortBy.Size" xml:space="preserve">
+    <value>Größe</value>
+  </data>
+  <data name="Common.SortBy.Path" xml:space="preserve">
+    <value>Pfad</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAllSafe" xml:space="preserve">
+    <value>Alle sicheren anwenden</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAll" xml:space="preserve">
+    <value>Alles anwenden</value>
+  </data>
+  <data name="Optimizer.Menu.ViewSource" xml:space="preserve">
+    <value>Quellcode anzeigen</value>
+  </data>
+  <data name="Bloatware.Menu.SelectAllSafe" xml:space="preserve">
+    <value>Alle sicheren auswählen</value>
+  </data>
+  <data name="Bloatware.Menu.DeselectAllSafe" xml:space="preserve">
+    <value>Alle sicheren abwählen</value>
+  </data>
+  <data name="Optimizer.Menu.HideApplied" xml:space="preserve">
+    <value>Angewendete ausblenden</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyMenu" xml:space="preserve">
+    <value>Anwenden</value>
+  </data>
+  <data name="Optimizer.Menu.BatchApply.Title" xml:space="preserve">
+    <value>Optimierungen werden angewendet</value>
+  </data>
+  <data name="Bloatware.Search.NoResults" xml:space="preserve">
+    <value>Keine Ergebnisse gefunden. Versuche einen anderen Suchbegriff oder Filter.</value>
+  </data>
+  <data name="Common.Filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="Common.SortBy" xml:space="preserve">
+    <value>Sortieren nach</value>
+  </data>
+  <data name="Sidebar.DiskCleanup" xml:space="preserve">
+    <value>Datenträgerbereinigung</value>
+  </data>
+  <data name="DiskCleanup.Header.Title" xml:space="preserve">
+    <value>Datenträgerbereinigung</value>
+  </data>
+  <data name="DiskCleanup.Header.Description" xml:space="preserve">
+    <value>Speicherplatz freigeben, indem temporäre Dateien und Cache entfernt werden</value>
+  </data>
+  <data name="DiskCleanup.TotalSpace" xml:space="preserve">
+    <value>Insgesamt freigebbarer Speicherplatz</value>
+  </data>
+  <data name="DiskCleanup.Button.Scan" xml:space="preserve">
+    <value>Scannen</value>
+  </data>
+  <data name="DiskCleanup.Button.SelectAll" xml:space="preserve">
+    <value>Alle auswählen</value>
+  </data>
+  <data name="DiskCleanup.Button.DeselectAll" xml:space="preserve">
+    <value>Auswahl aufheben</value>
+  </data>
+  <data name="DiskCleanup.Scanning" xml:space="preserve">
+    <value>Wird gescannt...</value>
+  </data>
+  <data name="DiskCleanup.Loading" xml:space="preserve">
+    <value>Bereinigungselemente werden geladen...</value>
+  </data>
+  <data name="DiskCleanup.Complete.Title" xml:space="preserve">
+    <value>Bereinigung abgeschlossen</value>
+  </data>
+  <data name="DiskCleanup.Complete.Message" xml:space="preserve">
+    <value>{0} Speicherplatz in {1} erfolgreich freigegeben</value>
+  </data>
+  <data name="DiskCleanup.Error.Title" xml:space="preserve">
+    <value>Bereinigungsfehler</value>
+  </data>
+  <data name="DiskCleanup.Error.Message" xml:space="preserve">
+    <value>Einige Dateien konnten nicht gelöscht werden. Sie werden möglicherweise von einem anderen Prozess verwendet.</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles" xml:space="preserve">
+    <value>Temporäre Dateien</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles.Description" xml:space="preserve">
+    <value>Von Anwendungen erstellte temporäre Benutzerdateien (ausgenommen das .net-Temp-Verzeichnis)</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp" xml:space="preserve">
+    <value>System-Temp-Dateien</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp.Description" xml:space="preserve">
+    <value>Temporäre Windows-Systemdateien</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate" xml:space="preserve">
+    <value>Windows-Update-Cache</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate.Description" xml:space="preserve">
+    <value>Heruntergeladene Windows-Update-Dateien, die nicht mehr benötigt werden</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch" xml:space="preserve">
+    <value>Prefetch-Dateien</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch.Description" xml:space="preserve">
+    <value>Anwendungs-Prefetch-Daten zur Beschleunigung des Ladens</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails" xml:space="preserve">
+    <value>Miniaturansichten-Cache</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails.Description" xml:space="preserve">
+    <value>Zwischengespeicherte Miniaturbilder für Explorer-Dateivorschauen</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin" xml:space="preserve">
+    <value>Papierkorb</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin.Description" xml:space="preserve">
+    <value>Gelöschte Dateien, die noch im Papierkorb gespeichert sind</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports" xml:space="preserve">
+    <value>Fehlerberichte</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports.Description" xml:space="preserve">
+    <value>Windows-Fehlerberichte und Absturzabbilddateien</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation" xml:space="preserve">
+    <value>Alte Windows-Installation (Windows.old)</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation.Description" xml:space="preserve">
+    <value>Dateien der vorherigen Windows-Installation, die nach einem großen Update oder Upgrade aufbewahrt wurden</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Laptop" xml:space="preserve">
+    <value>Laptop</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Desktop" xml:space="preserve">
+    <value>Desktop</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.Build" xml:space="preserve">
+    <value>Build {0}</value>
+  </data>
+  <data name="Bloatware.Header.Description" xml:space="preserve">
+    <value>Vorinstallierte Anwendungen verwalten und entfernen, die du nicht brauchst</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Header" xml:space="preserve">
+    <value>Systeminformationen</value>
+  </data>
+  <data name="DiskCleanup.ItemsSelected" xml:space="preserve">
+    <value>{0} ({1} Elemente ausgewählt)</value>
+  </data>
+  <data name="DiskCleanup.Button.Clean" xml:space="preserve">
+    <value>Bereinigen</value>
+  </data>
+  <data name="DiskCleanup.Button.CleanSelected" xml:space="preserve">
+    <value>Ausgewählte bereinigen ({0})</value>
+  </data>
+  <data name="DiskCleanup.EmptySize" xml:space="preserve">
+    <value>Keine Größe</value>
+  </data>
+  <data name="DiskCleanup.FilesCount" xml:space="preserve">
+    <value>{0} Dateien</value>
+  </data>
+  <data name="DiskCleanup.ItemsAndFilesSelected" xml:space="preserve">
+    <value>{0} ausgewählt • {1} Elemente • {2} Dateien</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Title" xml:space="preserve">
+      <value>Brauchst du Hilfe?</value>
+    </data>
+  <data name="Sidebar.StartupManager" xml:space="preserve">
+    <value>Autostart-Manager</value>
+  </data>
+  <data name="StartupManager.Header.Title" xml:space="preserve">
+    <value>Autostart-Manager</value>
+  </data>
+  <data name="StartupManager.Header.Description" xml:space="preserve">
+    <value>Anwendungen und Aufgaben verwalten, die beim Windows-Start automatisch ausgeführt werden.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other" xml:space="preserve">
+    <value>Sonstiges</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Description" xml:space="preserve">
+    <value>Öffnet die rohe JSON-Datei mit Wiederherstellungsdaten für diese Optimierung.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Description" xml:space="preserve">
+    <value>Öffnet den Quellcode dieser Optimierung im Browser.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Title" xml:space="preserve">
+    <value>Quellcode auf GitHub anzeigen</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Risk" xml:space="preserve">
+    <value>Risikostufe</value>
+  </data>
+  <data name="OptimizationDetailsDialog.TechnicalDetails" xml:space="preserve">
+    <value>Technische Details</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Id" xml:space="preserve">
+    <value>Optimierungs-ID</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Class" xml:space="preserve">
+    <value>Klassenname</value>
+  </data>
+  <data name="StartupManager.Apps.Title" xml:space="preserve">
+    <value>Autostart-Apps</value>
+  </data>
+  <data name="StartupManager.Apps.Description" xml:space="preserve">
+    <value>Anwendungen, die beim Windows-Start automatisch ausgeführt werden.</value>
+  </data>
+  <data name="StartupManager.Apps.CountSuffix" xml:space="preserve">
+    <value>{0} Elemente</value>
+  </data>
+  <data name="StartupManager.Tasks.Title" xml:space="preserve">
+    <value>Geplante Aufgaben (Anmeldung)</value>
+  </data>
+  <data name="StartupManager.Tasks.Description" xml:space="preserve">
+    <value>Windows-Aufgaben, die für die Ausführung bei der Anmeldung oder nach Zeitplan konfiguriert sind.</value>
+  </data>
+  <data name="StartupManager.Tasks.CountSuffix" xml:space="preserve">
+    <value>{0} Aufgaben</value>
+  </data>
+  <data name="StartupManager.Loading" xml:space="preserve">
+    <value>Autostart-Elemente werden gescannt...</value>
+  </data>
+  <data name="StartupManager.Loading.Hint" xml:space="preserve">
+    <value>Dies kann einen Moment dauern, während die Anwendung die Registry und Autostart-Ordner scannt.</value>
+  </data>
+  <data name="StartupManager.Empty.Title" xml:space="preserve">
+    <value>Keine Autostart-Elemente</value>
+  </data>
+  <data name="StartupManager.Empty.Description" xml:space="preserve">
+    <value>Auf diesem System wurden keine Autostart-Anwendungen oder geplanten Aufgaben gefunden.</value>
+  </data>
+  <data name="StartupManager.Menu.Refresh" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="Common.Toggle.On" xml:space="preserve">
+    <value>Ein</value>
+  </data>
+  <data name="Common.Toggle.Off" xml:space="preserve">
+    <value>Aus</value>
+  </data>
+  <data name="Common.SortBy.Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Common.Status.Applied" xml:space="preserve">
+    <value>Angewendet</value>
+  </data>
+  <data name="StartupManager.Menu.OpenSettings" xml:space="preserve">
+    <value>Einstellungen öffnen</value>
+  </data>
+  <!-- Scheduled Tasks (Startup Manager) -->
+  <data name="StartupManager.Tasks.HideMicrosoft" xml:space="preserve">
+    <value>Microsoft-Aufgaben ausblenden</value>
+  </data>
+  <!-- Sidebar -->
+  <data name="Sidebar.ScheduledTasks" xml:space="preserve">
+    <value>Geplante Aufgaben</value>
+  </data>
+  <!-- Scheduled Tasks Page -->
+  <data name="ScheduledTasks.Header.Title" xml:space="preserve">
+    <value>Geplante Aufgaben</value>
+  </data>
+  <data name="ScheduledTasks.Header.Description" xml:space="preserve">
+    <value>Windows-Aufgaben anzeigen und verwalten.</value>
+  </data>
+  <data name="ScheduledTasks.Loading" xml:space="preserve">
+    <value>Geplante Aufgaben werden geladen...</value>
+  </data>
+  <data name="ScheduledTasks.Loading.Hint" xml:space="preserve">
+    <value>Dies kann einen Moment dauern, während alle geplanten Aufgaben auf deinem System gescannt werden...</value>
+  </data>
+  <data name="ScheduledTasks.HideMicrosoft" xml:space="preserve">
+    <value>Microsoft-Aufgaben ausblenden</value>
+  </data>
+  <data name="ScheduledTasks.Menu.CreateTask" xml:space="preserve">
+    <value>Aufgabe erstellen</value>
+  </data>
+  <!-- Scheduled Tasks Actions -->
+  <data name="ScheduledTasks.Action.Details" xml:space="preserve">
+    <value>Details anzeigen</value>
+  </data>
+  <data name="ScheduledTasks.Action.Run" xml:space="preserve">
+    <value>Ausführen</value>
+  </data>
+  <data name="ScheduledTasks.Action.Stop" xml:space="preserve">
+    <value>Stoppen</value>
+  </data>
+  <data name="ScheduledTasks.Action.Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <!-- Scheduled Tasks Dialogs -->
+  <data name="ScheduledTasks.Dialog.DeleteTitle" xml:space="preserve">
+    <value>Geplante Aufgabe löschen</value>
+  </data>
+  <data name="ScheduledTasks.Dialog.DeleteMessage" xml:space="preserve">
+    <value>Möchtest du die Aufgabe "{0}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.</value>
+  </data>
+  <!-- Scheduled Tasks Details -->
+  <data name="ScheduledTasks.Details.Path" xml:space="preserve">
+    <value>Pfad</value>
+  </data>
+  <data name="ScheduledTasks.Details.Description" xml:space="preserve">
+    <value>Beschreibung</value>
+  </data>
+  <data name="ScheduledTasks.Details.Author" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="ScheduledTasks.Details.State" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ScheduledTasks.Details.Triggers" xml:space="preserve">
+    <value>Trigger</value>
+  </data>
+  <data name="ScheduledTasks.Details.Action" xml:space="preserve">
+    <value>Aktion</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastRun" xml:space="preserve">
+    <value>Letzte Ausführung</value>
+  </data>
+  <data name="ScheduledTasks.Details.NextRun" xml:space="preserve">
+    <value>Nächste Ausführung</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastResult" xml:space="preserve">
+    <value>Letztes Ergebnis</value>
+  </data>
+  <!-- Common -->
+  <data name="Common.Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="Common.SortBy.State" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ScheduledTasks.Menu.OpenSettings" xml:space="preserve">
+    <value>Aufgabenplanung öffnen</value>
+  </data>
+  <data name="ScheduledTasks.Details.Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Enabled.Title" xml:space="preserve">
+    <value>Aufgabe aktiviert</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Disabled.Title" xml:space="preserve">
+    <value>Aufgabe deaktiviert</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Toggle.Message" xml:space="preserve">
+    <value>{0} wurde erfolgreich aktualisiert.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Title" xml:space="preserve">
+    <value>Aufgabe gestartet</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Message" xml:space="preserve">
+    <value>{0} wird jetzt ausgeführt.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Title" xml:space="preserve">
+    <value>Aufgabe gestoppt</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Message" xml:space="preserve">
+    <value>{0} wurde gestoppt.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Title" xml:space="preserve">
+    <value>Aufgabe gelöscht</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Message" xml:space="preserve">
+    <value>{0} wurde gelöscht.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Title" xml:space="preserve">
+    <value>Aufgabe erstellt</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Message" xml:space="preserve">
+    <value>{0} wurde erfolgreich erstellt.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Error.Title" xml:space="preserve">
+
+    <value>Fehler</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Description" xml:space="preserve">
+      <value>Wenn du Hilfe bei der Optimierung brauchst oder Fragen hast, tritt unserer Community für schnellen Support bei.</value>
+    </data>
+  <data name="ScheduledTasks.Error.TaskNotFound" xml:space="preserve">
+      <value>Aufgabe nicht gefunden: {0}</value>
+    </data>
+  <data name="Service.Registry.Name" xml:space="preserve">
+    <value>Registrierung</value>
+  </data>
+  <data name="Service.Service.Name" xml:space="preserve">
+    <value>Dienst</value>
+  </data>
+  <data name="Service.ScheduledTask.Name" xml:space="preserve">
+    <value>Geplante Aufgabe</value>
+  </data>
+  <data name="Service.Shell.Name" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="Service.Registry.Description.Write" xml:space="preserve">
+    <value>Registrierungswert schreiben: {0}\{1}</value>
+  </data>
+  <data name="Service.Registry.Description.Delete" xml:space="preserve">
+    <value>Registrierungswert löschen: {0}\{1}</value>
+  </data>
+  <data name="Service.Service.Description.Change" xml:space="preserve">
+    <value>Dienst "{0}" auf Starttyp {1} ändern</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>Geplante Aufgabe aktivieren: {0}</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>Geplante Aufgabe deaktivieren: {0}</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedDisable" xml:space="preserve">
+    <value>Zugriff beim Deaktivieren der Aufgabe {0} verweigert</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedEnable" xml:space="preserve">
+    <value>Zugriff beim Aktivieren der Aufgabe {0} verweigert</value>
+  </data>
+  <data name="Revert.Registry.Description.Restore" xml:space="preserve">
+    <value>Registrierungswert wiederherstellen: {0}\{1}</value>
+  </data>
+  <data name="Revert.Registry.Description.Delete" xml:space="preserve">
+    <value>Registrierungswert löschen: {0}\{1}</value>
+  </data>
+  <data name="Revert.Service.Description.Restore" xml:space="preserve">
+    <value>Dienst "{0}" auf Starttyp {1} wiederherstellen</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>Geplante Aufgabe aktivieren: {0}</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>Geplante Aufgabe deaktivieren: {0}</value>
+  </data>
+  <data name="Revert.Shell.Description.Run" xml:space="preserve">
+    <value>{0}-Befehl ausführen: {1}</value>
+  </data>
+  <data name="Revert.Shell.Error.UnknownShellType" xml:space="preserve">
+    <value>Unbekannter Shell-Typ</value>
+  </data>
+  <data name="Revert.Shell.Error.CommandFailed" xml:space="preserve">
+    <value>Wiederherstellungsbefehl mit Exitcode {0} fehlgeschlagen</value>
+  </data>
+  <data name="Revert.UsbPower.Error.CommandFailed" xml:space="preserve">
+    <value>USB-Energiewiederherstellung mit Exitcode {0} fehlgeschlagen</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Title" xml:space="preserve">
+    <value>Abschlussbenachrichtigung anzeigen</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Description" xml:space="preserve">
+    <value>Zeigt eine Benachrichtigung an, wenn Optimierungen erfolgreich angewendet oder zurückgesetzt wurden.</value>
+  </data>
+  <data name="Optimizations.Loading" xml:space="preserve">
+    <value>Optimierungen werden geladen...</value>
+  </data>
+  <data name="Optimizations.Loading.Hint" xml:space="preserve">
+    <value>Bitte warten...</value>
+  </data>
+  <data name="Common.OpenFolder" xml:space="preserve">
+    <value>Ordner öffnen</value>
+  </data>
+  <data name="Common.Other" xml:space="preserve">
+    <value>Sonstiges</value>
+  </data>
+  <data name="Sidebar.Customize" xml:space="preserve">
+    <value>Anpassen</value>
+  </data>
+  <data name="Customize.Title" xml:space="preserve">
+    <value>Anpassen</value>
+  </data>
+  <data name="Customize.SystemFeatures.Name" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="Customize.SystemFeatures.Description" xml:space="preserve">
+    <value>Kernfunktionen und Verhalten des Systems</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
+    <value>Eingabeeinstellungen</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
+    <value>NumLock beim Start</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Description" xml:space="preserve">
+    <value>NumLock-Status auf dem Windows-Anmeldebildschirm.</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
+    <value>Das Aktivieren von NumLock beim Start stellt sicher, dass der Ziffernblock direkt nach der Anmeldung bereit ist, und vermeidet jedes Mal manuelles Umschalten.</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
+    <value>Energieeinstellungen</value>
+  </data>
+  <data name="Customize.Desktop.Name" xml:space="preserve">
+    <value>Desktop</value>
+  </data>
+  <data name="Customize.Desktop.Description" xml:space="preserve">
+    <value>Desktop-Symbole und Verknüpfungseinstellungen</value>
+  </data>
+  <data name="Customize.Desktop.Section.Icons" xml:space="preserve">
+    <value>Desktop-Symbole</value>
+  </data>
+  <data name="Customize.Desktop.Section.Behaviors" xml:space="preserve">
+    <value>Verknüpfungsverhalten</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Name" xml:space="preserve">
+    <value>Dieser PC</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Description" xml:space="preserve">
+    <value>Zeigt das Symbol "Dieser PC" auf deinem Desktop an</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Name" xml:space="preserve">
+    <value>Papierkorb</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Description" xml:space="preserve">
+    <value>Zeigt das Papierkorb-Symbol auf deinem Desktop an</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Name" xml:space="preserve">
+    <value>Benutzerdateien</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Description" xml:space="preserve">
+    <value>Zeigt deinen Benutzerprofilordner als Desktop-Symbol an</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Name" xml:space="preserve">
+    <value>Netzwerk</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Description" xml:space="preserve">
+    <value>Zeigt das Netzwerk-Symbol auf deinem Desktop an</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Name" xml:space="preserve">
+    <value>Systemsteuerung</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Description" xml:space="preserve">
+    <value>Zeigt das Systemsteuerung-Symbol auf deinem Desktop an</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Name" xml:space="preserve">
+    <value>Desktop-Symbole</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Description" xml:space="preserve">
+    <value>Zeigt oder blendet alle Desktop-Symbole gleichzeitig ein oder aus</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Name" xml:space="preserve">
+    <value>Verknüpfungspfeil</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Description" xml:space="preserve">
+    <value>Zeigt oder blendet den Verknüpfungspfeil auf Desktop-Symbolen ein oder aus</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Name" xml:space="preserve">
+    <value>Mit "Dieser PC" starten</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Description" xml:space="preserve">
+    <value>Standardort des Datei-Explorers (Dieser PC oder Schnellzugriff).</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Name" xml:space="preserve">
+    <value>Bing-Suche</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Description" xml:space="preserve">
+    <value>Bing-Websuche-Integration in Windows-Suche und Startmenüergebnissen.</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Recommendation.Reason" xml:space="preserve">
+    <value>Das Deaktivieren der Bing-Suche verhindert, dass Webabfragen lokale Suchergebnisse überladen, und verbessert die Suchgeschwindigkeit.</value>
+  </data>
+  <data name="Button.Accept" xml:space="preserve">
+    <value>Akzeptieren</value>
+  </data>
+  <data name="LegalDialog.Title" xml:space="preserve">
+    <value>Rechtliche Vereinbarung</value>
+  </data>
+  <data name="LegalDialog.Intro.ThankYou" xml:space="preserve">
+    <value>Danke, dass du optimizerDuck gewählt hast.</value>
+  </data>
+  <data name="LegalDialog.Intro.Safety" xml:space="preserve">
+    <value>Um Transparenz und deine Sicherheit zu gewährleisten, kann optimizerDuck bestimmte Systemeinstellungen und Registry-Konfigurationen anpassen.</value>
+  </data>
+  <data name="LegalDialog.Intro.Review" xml:space="preserve">
+    <value>Bitte nimm dir einen Moment Zeit, um die folgenden Dokumente zu prüfen. Wenn du fortfährst, stimmst du diesen Bedingungen zu.</value>
+  </data>
+  <data name="LegalDialog.Link.TermsOfService" xml:space="preserve">
+    <value>Nutzungsbedingungen</value>
+  </data>
+  <data name="LegalDialog.Link.PrivacyPolicy" xml:space="preserve">
+    <value>Datenschutzerklärung</value>
+  </data>
+  <data name="LegalDialog.Link.Disclaimer" xml:space="preserve">
+    <value>Haftungsausschluss</value>
+  </data>
+  <data name="LegalDialog.Warning.Title" xml:space="preserve">
+    <value>Nutzung auf eigene Gefahr</value>
+  </data>
+  <data name="LegalDialog.Warning.Message" xml:space="preserve">
+    <value>Wir empfehlen, vor dem Anwenden von Änderungen eine Sicherung zu erstellen.</value>
+  </data>
+  <data name="Dialog.PendingChanges.Title" xml:space="preserve">
+    <value>Änderungen anwenden</value>
+  </data>
+  <data name="Dialog.PendingChanges.Content" xml:space="preserve">
+    <value>Einige Änderungen erfordern einen Neustart, um wirksam zu werden. Was möchtest du vor dem Beenden tun?</value>
+  </data>
+  <data name="Dialog.PendingChanges.CloseButton" xml:space="preserve">
+    <value>Trotzdem beenden</value>
+  </data>
+  <data name="Dialog.PendingChanges.PrimaryButton" xml:space="preserve">
+    <value>PC neu starten</value>
+  </data>
+  <data name="Dialog.PendingChanges.SecondaryButton" xml:space="preserve">
+    <value>Explorer neu starten</value>
+  </data>
+  <data name="Settings.About.Documentation.Title" xml:space="preserve">
+    <value>Dokumentation</value>
+  </data>
+  <data name="Settings.About.Documentation.Description" xml:space="preserve">
+    <value>Dokumentation, Nutzungsanleitungen und FAQs anzeigen.</value>
+  </data>
+  <data name="TitleBar.Support" xml:space="preserve">
+    <value>Projekt unterstützen</value>
+  </data>
+  <data name="TitleBar.Discord" xml:space="preserve">
+    <value>Der Discord-Community beitreten</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Developer" xml:space="preserve">
+    <value>Entwickler</value>
+  </data>
+  <!-- Developer Mode -->
+  <data name="Customize.SystemFeatures.DeveloperMode.Name" xml:space="preserve">
+    <value>Entwicklermodus</value>
+  </data>
+  <data name="Customize.SystemFeatures.DeveloperMode.Description" xml:space="preserve">
+    <value>Aktiviert den Windows-Entwicklermodus für Sideloading von Apps, Geräteportal, SSH-Server und Entwicklungsfunktionen.</value>
+  </data>
+  <data name="Customize.SystemFeatures.DeveloperMode.Recommendation.Reason" xml:space="preserve">
+    <value>Der Entwicklermodus ermöglicht Sideloading und Diagnosefunktionen, die für App-Entwicklung und Debugging wichtig sind.</value>
+  </data>
+  <!-- Allow All Trusted Apps -->
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Name" xml:space="preserve">
+    <value>Alle vertrauenswürdigen Apps zulassen</value>
+  </data>
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Description" xml:space="preserve">
+    <value>Ermöglicht die Installation aller vertrauenswürdigen Windows-Store-Apps, ohne dass der Entwicklermodus aktiviert sein muss.</value>
+  </data>
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Recommendation.Reason" xml:space="preserve">
+    <value>Das Zulassen aller vertrauenswürdigen Apps ermöglicht Sideloading ohne Entwicklermodus; das Deaktivieren beschränkt Installationen auf den Microsoft Store.</value>
+  </data>
+  <!-- Long Paths -->
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Name" xml:space="preserve">
+    <value>Unterstützung langer Pfade (&gt;260 Zeichen)</value>
+  </data>
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Description" xml:space="preserve">
+    <value>Aktiviert Win32-Unterstützung für lange Pfade im Datei-Explorer und erlaubt Dateipfade, die länger als die traditionelle Grenze von 260 Zeichen sind.</value>
+  </data>
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Recommendation.Reason" xml:space="preserve">
+    <value>Die Unterstützung langer Pfade verhindert Dateizugriffsfehler beim Arbeiten mit tief verschachtelten Verzeichnissen oder Projekten mit langen Namen.</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Name" xml:space="preserve">
+    <value>Suchfeldanzeige</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Description" xml:space="preserve">
+    <value>Steuert, wie Suchschaltfläche und Suchfeld in der Taskleiste angezeigt werden.</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.Hidden" xml:space="preserve">
+    <value>Ausgeblendet</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.Icon" xml:space="preserve">
+    <value>Nur Symbol</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.IconAndLabel" xml:space="preserve">
+    <value>Symbol + Beschriftung</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.SearchBox" xml:space="preserve">
+    <value>Suchfeld</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarLastActiveClick.Name" xml:space="preserve">
+    <value>Letztaktives Fenster per Klick</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarLastActiveClick.Description" xml:space="preserve">
+    <value>Beim Klicken auf ein Taskleistensymbol wird sofort das zuletzt aktive Fenster dieser App geöffnet.</value>
+  </data>
+  <data name="Customize.SystemFeatures.ShowBatteryPercentage.Name" xml:space="preserve">
+    <value>Akkuladung in Prozent anzeigen</value>
+  </data>
+  <data name="Customize.SystemFeatures.ShowBatteryPercentage.Description" xml:space="preserve">
+    <value>Zeigt die Akkuladung in Prozent neben dem Akkusymbol im Infobereich an.</value>
+  </data>
+</root>

--- a/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
+++ b/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
@@ -53,6 +53,7 @@ public partial class SettingsViewModel(
     public ObservableCollection<LanguageOption> Languages { get; } =
     [
         new() { DisplayName = "English", Culture = new CultureInfo("en-US") },
+        new() { DisplayName = "Deutsch", Culture = new CultureInfo("de-DE") },
         new() { DisplayName = "Français", Culture = new CultureInfo("fr-FR") },
         new() { DisplayName = "Tiếng Việt", Culture = new CultureInfo("vi-VN") },
         new() { DisplayName = "正體中文", Culture = new CultureInfo("zh-TW") },


### PR DESCRIPTION
## Summary
- add a complete German (`de-DE`) resource file
- add Deutsch to the language selector and localization docs
- make localization-sensitive tests run with a fixed English test culture
- use a stable demand-start Windows service in the service startup test

## Tests
- `dotnet restore optimizerDuck.slnx`
- `dotnet build optimizerDuck.slnx --configuration Release --no-restore`
- `dotnet test optimizerDuck.Test/optimizerDuck.Test.csproj --configuration Release --no-build` (181 passed)
- German resource validation: 569/569 keys, no missing/extra keys, placeholders match English
- `git diff --check`
- `csharpier check` on changed C# files