### PR TITLE
i18n: add Arabic (ar-SA) translation

### DIFF
--- a/README.ar-SA.md
+++ b/README.ar-SA.md
@@ -1,0 +1,366 @@
+<div align="center">
+
+<a href="https://optimizerduck.vercel.app/"><img src="./.github/assets/optimizerDuck.png" alt="optimizerDuck Banner" title="optimizerDuck"/></a>
+
+# [optimizerDuck](https://optimizerduck.vercel.app/)
+
+**‏optimizerDuck أداة مجانية مفتوحة المصدر لتحسين ويندوز، تركّز على الأداء والخصوصية والبساطة.**
+
+<a href="https://trendshift.io/repositories/36187" target="_blank"><img src="https://trendshift.io/api/badge/repositories/36187" alt="itsfatduck%2FoptimizerDuck | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+<br>
+[![Release](https://img.shields.io/github/release/itsfatduck/optimizerDuck?color=fed114&label=Release&style=flat-square)](https://github.com/itsfatduck/optimizerDuck/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/itsfatduck/optimizerDuck/total?label=Downloads&style=flat-square&color=lightgreen)](https://github.com/itsfatduck/optimizerDuck/releases)
+[![Stars](https://img.shields.io/endpoint?url=https://api.pinstudios.net/api/badges/stars/itsfatduck/optimizerDuck&style=flat-square)](https://github.com/itsfatduck/optimizerDuck/stargazers)
+[![License](https://img.shields.io/badge/License-GPL_v3-red?style=flat-square)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1091675679994675240?color=5865f2&label=Discord&style=flat-square)](https://discord.gg/tDUBDCYw9Q)
+<br>
+[![CI](https://github.com/itsfatduck/optimizerDuck/actions/workflows/ci.yml/badge.svg)](https://github.com/itsfatduck/optimizerDuck/actions/workflows/ci.yml)
+[![.NET Latest](https://img.shields.io/badge/.NET_Runtime-Latest-ef99dd?style=flat-square)](https://dotnet.microsoft.com/en-us/download)
+[![Supported OS](https://img.shields.io/badge/Supported-Windows_10%2B_x64-0078d4?style=flat-square)](https://www.microsoft.com/en-us/software-download/)
+
+**[البداية السريعة](https://optimizerduck.vercel.app/docs/guides/getting-started) | [كيف يعمل](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [الأسئلة الشائعة](https://optimizerduck.vercel.app/docs/faq/general)**
+
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | **العربية**
+
+<details>
+<summary>⭐ سجل النجوم</summary>
+
+إذا ساعدك optimizerDuck في تحسين جهازك، ففكّر في منح المستودع ⭐ ومشاركته مع الآخرين.
+كل نجمة تساعد على تحفيز التحسينات القادمة.
+
+<p align="center">
+ <a href="https://www.star-history.com/itsfatduck/optimizerduck">
+  <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=itsfatduck/optimizerDuck&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=itsfatduck/optimizerDuck" />
+   <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=itsfatduck/optimizerDuck" />
+  </picture>
+ </a>
+</p>
+
+<a href="https://www.star-history.com/?repos=itsfatduck%2FoptimizerDuck&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=itsfatduck/optimizerDuck&type=date&theme=dark&legend=top-left&sealed_token=UNXQhgyDBTZTQe1TE_Amu7Y7vpRg39O9VlDWdODQoVZHQMYgQvez_20mmRYsz_G_4P0WqF9EcECI9q3FgCwrudjZ0tvJ6st0cC6W0H6RPKncHmlV1RtXn1ys51oMBWeTQ8nkSmR9huOtNdEp4jh_wiWqmmc7j6HgfHRK9WlbIoHnGgLyskwm6agLLmWR" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=itsfatduck/optimizerDuck&type=date&legend=top-left&sealed_token=UNXQhgyDBTZTQe1TE_Amu7Y7vpRg39O9VlDWdODQoVZHQMYgQvez_20mmRYsz_G_4P0WqF9EcECI9q3FgCwrudjZ0tvJ6st0cC6W0H6RPKncHmlV1RtXn1ys51oMBWeTQ8nkSmR9huOtNdEp4jh_wiWqmmc7j6HgfHRK9WlbIoHnGgLyskwm6agLLmWR" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=itsfatduck/optimizerDuck&type=date&legend=top-left&sealed_token=UNXQhgyDBTZTQe1TE_Amu7Y7vpRg39O9VlDWdODQoVZHQMYgQvez_20mmRYsz_G_4P0WqF9EcECI9q3FgCwrudjZ0tvJ6st0cC6W0H6RPKncHmlV1RtXn1ys51oMBWeTQ8nkSmR9huOtNdEp4jh_wiWqmmc7j6HgfHRK9WlbIoHnGgLyskwm6agLLmWR" />
+ </picture>
+</a>
+
+<a href="https://starmapper.bruniaux.com/itsfatduck/optimizerDuck">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://starmapper.bruniaux.com/api/map-image/itsfatduck/optimizerDuck?theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://starmapper.bruniaux.com/api/map-image/itsfatduck/optimizerDuck?theme=light" />
+    <img alt="StarMapper" src="https://starmapper.bruniaux.com/api/map-image/itsfatduck/optimizerDuck" />
+  </picture>
+</a>
+
+</details>
+
+<img src="./.github/assets/app.png" alt="optimizerDuck Dark Mode" title="optimizerDuck Dark Mode" width="800"/>
+
+</div>
+
+---
+
+<div dir="rtl">
+
+## البداية السريعة
+
+1. حمّل الأداة من **[صفحة الإصدارات على GitHub](https://github.com/itsfatduck/optimizerDuck/releases/latest)**
+2. شغّل ملف `.exe` مباشرة، لا حاجة إلى تثبيت
+3. اختر التحسينات التي تريدها وطبّقها، ثم أعد تشغيل الجهاز عندما تكون جاهزًا
+
+> [!TIP]
+> أنشئ دائمًا **نقطة استعادة للنظام** قبل إجراء أي تغييرات.
+
+> [!NOTE]
+> | | اللغة | الاسم الأصلي | المترجم |
+> |------|----------|-------------|------------|
+> | 🇺🇸 | الإنجليزية (الولايات المتحدة) | English | الأساسية والموصى بها |
+> | 🇻🇳 | الفيتنامية | Tiếng Việt | [itsfatduck](https://github.com/itsfatduck) |
+> | 🇹🇼 | الصينية التقليدية | 正體中文 | [abc0922001](https://github.com/abc0922001) |
+> | 🇨🇳 | الصينية المبسّطة | 简体中文 | [wcxu21](https://github.com/wcxu21) |
+> | 🇷🇺 | الروسية | Русский | [Foodhead](https://github.com/Foodhead) |
+> | 🇫🇷 | الفرنسية | Français | [Robocnop](https://github.com/Robocnop) |
+> | 🇩🇪 | الألمانية | Deutsch | [pixeldepartment](https://github.com/pixeldepartment) |
+> | 🇮🇱 | العبرية | עברית | [yosef-chai](https://github.com/yosef-chai) |
+> | 🇰🇷 | الكورية | 한국어 | [klfnn](https://github.com/klfnn) |
+> | 🇪🇸 | الإسبانية | Español | [thexxtt](https://github.com/thexxtt) |
+> | 🇯🇵 | اليابانية | 日本語 | [zerofrip](https://github.com/zerofrip) |
+> | 🇵🇱 | البولندية | Polski | [dudus2000](https://github.com/dudus2000) |
+> | 🇧🇷 | البرتغالية (البرازيل) | Português (Brasil) | [mhanelia](https://github.com/mhanelia) |
+> | 🇹🇷 | التركية | Türkçe | [amhunter1](https://github.com/amhunter1) |
+> | 🇸🇦 | العربية | العربية | [s5xx5s](https://github.com/s5xx5s) |
+>
+> تريد إضافة لغتك؟ راجع [CONTRIBUTING.md](./CONTRIBUTING.md) ([اليابانية](./CONTRIBUTING.ja-JP.md)، [التركية](./CONTRIBUTING.tr-TR.md)).
+
+---
+
+## ما الذي يفعله optimizerDuck ولماذا يهم
+
+يعمل ويندوز بشكل ممتاز افتراضيًا. لكن أي تثبيت جديد يتضمن أيضًا خدمات تعمل في الخلفية، وقياسًا عن بُعد (Telemetry)، وتطبيقات مثبّتة مسبقًا، ومهامًّ مجدولة تستمر في العمل حتى لو لم تستخدمها أبدًا. وهذه تستهلك موارد النظام مثل المعالج والذاكرة والقرص والشبكة في الخلفية.
+
+وفي الوقت نفسه، هناك إعدادات كثيرة قادرة على تحسين الأداء أو تقليل زمن الاستجابة أو توفير تجربة أكثر سلاسة، لكنها غير مفعّلة افتراضيًا.
+
+يجمع optimizerDuck كل ذلك في مكان واحد. يساعدك على تحسين ويندوز، وإزالة المكوّنات غير الضرورية، وتخصيص إعدادات النظام، وإدارة ميزات ويندوز الشائعة دون التنقيب في الريجستري أو نهج المجموعة (Group Policy) أو PowerShell.
+
+كما يتضمن أدوات إدارة مدمجة تتيح لك رؤية ما يعمل، وإزالة ما لا تحتاجه، واستعادة التغييرات وقتما لزم.
+
+**[لماذا نحسّن ويندوز؟](#لماذا-نحسّن-ويندوز-بدل-ترقية-العتاد-فقط)**
+
+### تحسينات النظام
+
+أكثر من 30 تعديلًا موزّعة على 6 فئات، لكل منها وصف واضح وتقييم للخطورة، لتعرف بالضبط ما يفعله كل تغيير قبل تطبيقه.
+
+| الفئة | ما تغطيه |
+| :--- | :--- |
+| **الأداء** | ضبط تقسيم Service Host حسب حجم ذاكرتك، وتعديل أولويات العمليات، وتقليل زمن استجابة لوحة المفاتيح، وتحسينات مجدول الوسائط المتعددة للعب أكثر سلاسة |
+| **الخصوصية** | تعطيل القياس عن بُعد (Telemetry) وتقارير الأخطاء ومعرّف الإعلانات وتتبّع الموقع و Cortana و Copilot واقتراحات المحتوى |
+| **معالج الرسومات** | تعديلات ريجستري خاصة بكل مُصنِّع لكروت AMD و NVIDIA و Intel، تشمل حالات الطاقة وتقنين الترددات وزمن استجابة العرض |
+| **الطاقة** | تعطيل الإسبات وبدء التشغيل السريع، وإيقاف التعليق الانتقائي لمنافذ USB، وتثبيت خطة طاقة مخصصة عالية الأداء، وتعطيل خنق الطاقة |
+| **التطبيقات المرفقة والخدمات** | منع إعادة تثبيت تطبيقات الشركة المصنّعة، وضبط أنواع بدء التشغيل لأكثر من 200 خدمة في ويندوز |
+| **تجربة المستخدم** | إزالة تأخير ظهور القوائم، وتعطيل المؤثرات البصرية مثل حركات شريط المهام والشفافية للحصول على استجابة أسرع |
+
+> [!NOTE]
+> التحسينات هنا مستندة إلى بحث في أدوات معروفة ذات قواعد مستخدمين كبيرة، ولا شيء منها مولّد آليًا أو مُضاف عشوائيًا. كل تعديل مختار لأثره الحقيقي على أرض الواقع.
+
+### التخصيص
+
+لا حاجة للتنقيب في الريجستري، فقط مفاتيح تبديل وقوائم منسدلة وحقول رقمية في مكان واحد. وهي منظّمة في أربع فئات:
+
+- **سطح المكتب**: إظهار أو إخفاء الأيقونات (هذا الكمبيوتر، سلة المحذوفات، الشبكة، ملفات المستخدم، لوحة التحكم)، وإزالة سهم الاختصار المتراكب
+- **التفضيلات**: محاذاة شريط المهام، والأدوات المصغّرة، وزرّي عرض المهام وإنهاء المهمة، والثواني في الساعة، والوضع الداكن، وامتدادات الملفات، والملفات المخفية، وسجل الحافظة، والعرض المضغوط، ومساعد الإرساء، ومربعات اختيار العناصر، وقائمة السياق الكلاسيكية، وبحث Bing
+- **الألعاب**: وضع الألعاب، و Game Bar، والتسجيل في الخلفية، وتسريع الفأرة، وتحسينات ملء الشاشة، وجدولة معالج الرسومات المُسرَّعة بالعتاد
+- **النظام**: تفعيل NumLock عند الإقلاع
+
+### الأدوات المدمجة
+
+| الأداة | ما تفعله |
+| :--- | :--- |
+| **لوحة معلومات النظام** | اعرض تفاصيل المعالج والذاكرة وكرت الشاشة وأقراص التخزين ونظام التشغيل في لوحة واحدة |
+| **مدير بدء التشغيل** | شاهد كل تطبيق ومهمة تعمل عند الإقلاع، وفعّلها أو عطّلها، وافتح موقع ملفها |
+| **المهام المجدولة** | تصفّح مهام ويندوز المجدولة وشغّلها أو أوقفها أو فعّلها أو عطّلها أو احذفها |
+| **تنظيف القرص** | افحص وامسح الملفات المؤقتة وذاكرة النظام المخبّأة وبقايا تحديثات ويندوز والتحميل المسبق والصور المصغّرة وسلة المحذوفات وملفات تفريغ الأعطال وتثبيتات ويندوز القديمة |
+| **مزيل التطبيقات المرفقة** | يسرد جميع حزم AppX القابلة للإزالة مع شارات خطورة (آمن، بحذر، غير معروف) لتختار ما تريد إزالته |
+
+### لماذا نحسّن ويندوز بدل ترقية العتاد فقط؟
+
+أسرع طريقة لتحسين الأداء هي دائمًا ترقية العتاد. معالج أفضل، أو كرت شاشة أقوى، أو ذاكرة أكبر، أو قرص SSD أسرع، كلها ستمنحك تحسينًا أكبر بكثير من التعديلات البرمجية وحدها.
+
+لكن العتاد جزء واحد من الصورة.
+
+صُمِّم ويندوز ليعمل على مئات الملايين من الأجهزة باختلاف عتادها وأحمالها ومستخدميها. ولهذا تشحن مايكروسوفت ويندوز بإعدادات تعطي الأولوية للتوافق والاستقرار وعمر البطارية وسهولة الاستخدام، بدلًا من الأداء الأقصى.
+
+والنتيجة أن تثبيت ويندوز الافتراضي يتضمن كثيرًا من الخدمات العاملة في الخلفية والمهام المجدولة والقياس عن بُعد وميزات توفير الطاقة والتطبيقات المثبّتة مسبقًا التي قد لا يحتاجها كثير من المستخدمين أبدًا.
+
+وهذا يصدق بشكل خاص بعد إعادة تثبيت ويندوز. فحتى بعد تثبيت جميع التعريفات والتحديثات، تبقى إعدادات مفيدة كثيرة متعلقة بالأداء دون تغيير، بينما تستمر المكوّنات غير الضرورية في العمل بالخلفية.
+
+تحسين ويندوز ببساطة هو تقليل الأعباء غير الضرورية حتى يصرف جهازك موارده على ما يهمك فعلًا، سواء كان ألعابًا أو برمجة أو إنتاج محتوى أو عملًا يوميًا.
+
+لن يضاعف عدد الإطارات لديك بطريقة سحرية، لكنه قادر على تقليل النشاط في الخلفية، وخفض زمن استجابة النظام، وتحسين سرعة الاستجابة، ومساعدة عتادك على الأداء بثبات أكبر.
+
+وهذا أيضًا أحد أسباب ترشيح كثيرين لنظام لينكس لأداء أفضل وأعباء نظام أقل. فإذا كنت تفضّل البقاء على ويندوز لتوافق برامجه وتجربته المألوفة، فإن optimizerDuck يساعدك على الحصول على أفضل تجربة ممكنة دون تغيير نظام التشغيل.
+
+### متى ينبغي أن أحسّن ويندوز؟
+
+أفضل وقت هو **بعد إعداد تثبيت جديد لويندوز**.
+
+نوصي بهذا الترتيب:
+
+1. ثبّت ويندوز.
+2. ثبّت جميع تعريفات العتاد (اللوحة الأم، كرت الشاشة، الشبكة، الصوت، وغيرها).
+3. شغّل **Windows Update** حتى لا تبقى تحديثات متاحة.
+4. ثبّت جميع **التحديثات الاختيارية**.
+5. افتح **Microsoft Store** وحدّث جميع التطبيقات المدمجة.
+6. ثبّت البرامج والألعاب التي تستخدمها عادةً.
+7. طبّق تحسينات optimizerDuck التي تفضّلها.
+8. استخدم أدوات optimizerDuck المدمجة لإزالة التطبيقات غير الضرورية وتنظيف ويندوز وإدارة برامج بدء التشغيل.
+
+اتباع هذا الترتيب يساعد على تجنّب قيام تحديثات ويندوز أو التعريفات بإلغاء تحسيناتك لاحقًا.
+
+> [!TIP]
+> يختار كثير من المستخدمين المتقدمين تعطيل تحديثات ويندوز التلقائية مؤقتًا بعد الانتهاء من الإعداد. فالتحديثات الكبيرة قد تعيد الإعدادات الافتراضية أو تعيد تثبيت مكوّنات معينة أو تلغي بعض التحسينات. وإذا فعلت ذلك، فتذكّر إعادة تفعيل Windows Update دوريًا لتثبيت التحديثات الأمنية المهمة قبل تعطيله مجددًا.
+
+> [!NOTE]
+> كل تحسين يوفّره optimizerDuck يمكن تنفيذه يدويًا أيضًا. الهدف من optimizerDuck هو ببساطة جعل تحسين ويندوز أسهل وأأمن وأكثر راحة.
+
+---
+
+## الأمان
+
+تغيير إعدادات النظام ينطوي على مخاطرة. وقد بُني optimizerDuck حول مبدأ قابلية التراجع وتحكّم المستخدم.
+
+راجع [سياسة الخصوصية](./PRIVACY.md) لتفاصيل ممارساتنا في التعامل مع البيانات.
+
+- **نسخ احتياطية تلقائية**: كل تغيير يكتب ملف تراجع في مجلد محلي. يمكنك استعادة تعديل بعينه أو التراجع عن كل شيء
+- **تراجع بنقرة واحدة**: تراجع عن أي تحسين مُطبَّق من الواجهة بنقرة واحدة
+- **تقييمات الخطورة**: كل تعديل موسوم بـ آمن أو بحذر أو للخبراء بحسب أثره المحتمل
+- **لا شيء مُفعّل افتراضيًا**: لا يعمل شيء حتى تختاره أنت. الأداة لا تفعّل أي شيء من تلقاء نفسها
+- **اقتراح نقطة استعادة**: قبل أول تحسين، يقترح التطبيق إنشاء نقطة استعادة لويندوز
+
+---
+
+## الأسئلة الشائعة
+
+> [!TIP]
+> زُر [صفحة الأسئلة الشائعة على الموقع](https://optimizerduck.vercel.app/docs/faq/general) لمزيد من الأسئلة والأجوبة.
+
+### هل استخدام optimizerDuck آمن؟
+
+نعم. optimizerDuck **مفتوح المصدر** بالكامل (رخصة GPL v3)، ما يعني أن بإمكان أي شخص فحص الكود المصدري أو تدقيقه أو بناؤه بنفسه. وكل إصدار يُبنى تلقائيًا عبر **GitHub Actions** من المصدر العلني؛ بلا تعديلات خفية ولا ملفات تنفيذية غير موقّعة تُحقن بعد البناء. وإذا فضّلت، يمكنك استنساخ المستودع وبناء ملف `.exe` بنفسك بأمر `dotnet build` واحد.
+
+التطبيق **لا** يجمع أي قياسات عن بُعد أو بيانات استخدام أو معلومات شخصية. راجع [سياسة الخصوصية](./PRIVACY.md).
+
+### هل يحسّن optimizerDuck الأداء فعلًا، أو يقلل زمن الاستجابة، أو يسرّع الشبكة؟
+
+قد يساعد. كل تحسين في optimizerDuck **مستند إلى بحث في أدوات معروفة وأدلة المجتمع وتوصيات مصنّعي العتاد**، ولا شيء منه مولّد آليًا أو مُضاف عشوائيًا أو مختلق. وكل تعديل يعالج إعدادًا حقيقيًا يضبطه ويندوز بتحفّظ افتراضيًا (مثل تجميع Service Host، وحالات طاقة كرت الشاشة، وخنق الشبكة، وجدولة العمليات).
+
+لا توجد هنا حيل ريجستري وهمية؛ فلكل تغيير غرض موثّق وأثر حقيقي مدعوم باختبارات المجتمع ووثائق المصنّعين.
+
+### لماذا يحذّر Windows SmartScreen أو Defender عند التحميل؟
+
+‏optimizerDuck غير موقّع رقميًا لأن شهادات توقيع الكود مكلفة على المشاريع مفتوحة المصدر. وعندما يصادف ويندوز ملفًا تنفيذيًا غير موقّع مُنزَّلًا من الإنترنت، يعرض SmartScreen تحذيرًا افتراضيًا. هذا أمر طبيعي و**لا** يعني أن الملف غير آمن.
+
+لتجاوزه، اضغط **"More info" ثم "Run anyway"**. وإذا كنت ما زلت قلقًا:
+
+- ابنِ ملف `.exe` بنفسك من [المصدر](https://github.com/itsfatduck/optimizerDuck)
+- ارفع الملف إلى بيئات تحليل مثل ANY.RUN للتحقق المستقل
+
+### هل يمكنني التراجع عن التغييرات إذا حدث خطأ؟
+
+نعم. كل تحسين ينشئ ملف تراجع قبل التطبيق. يمكنك التراجع عن تعديلات مفردة أو عن كل شيء من الواجهة بنقرة واحدة. كما يقترح التطبيق إنشاء نقطة استعادة لويندوز قبل أول تحسين.
+
+### هل يعمل على ويندوز 10 وويندوز 11؟
+
+نعم. يدعم optimizerDuck **ويندوز 10 (‏x64)** و**ويندوز 11 (‏x64)**.
+
+### هل أحتاج صلاحيات مسؤول؟
+
+نعم. يعدّل optimizerDuck إعدادات النظام وريجستري ويندوز، لذا يتطلب صلاحيات المسؤول للعمل.
+
+### هل يجمع optimizerDuck بياناتي؟
+
+لا. التطبيق خالٍ تمامًا من القياس عن بُعد والتحليلات وأي اتصال خارجي. يعمل بالكامل دون اتصال ولا يرسل أي بيانات إلى أي جهة.
+
+### لماذا تُظهر إدارة المهام استهلاك معالج 100% بعد تطبيق خطة الطاقة؟ ([#29](https://github.com/itsfatduck/optimizerDuck/issues/29))
+
+خلل عرض معروف في إدارة المهام تسببه خطط الطاقة غير الافتراضية، فتُبلّغ خطأً عن استهلاك 100% للمعالج على بعض الأجهزة بينما الحمل الفعلي طبيعي. المشكلة بصرية فقط و**لا** تؤثر على الأداء الحقيقي ولا تسبب ارتفاع الحرارة. وإذا لم ترغب بها، فببساطة عطّل هذا التحسين.
+
+---
+
+## استكشاف الأخطاء
+
+> [!TIP]
+> زُر [صفحة استكشاف الأخطاء](https://optimizerduck.vercel.app/docs/faq/troubleshooting) لإرشادات أكثر تفصيلًا وحلول للمشاكل المعروفة.
+
+### التطبيق لا يبدأ أو ينهار عند التشغيل
+
+تأكد أنك تشغّله **كمسؤول**، فـ optimizerDuck يتطلب صلاحيات مرتفعة. وإذا استمر الانهيار، فحمّل أحدث إصدار من [صفحة الإصدارات](https://github.com/itsfatduck/optimizerDuck/releases/latest)؛ فقد لا تكون النسخة القديمة متوافقة مع إصدار ويندوز لديك.
+
+### التغييرات لا تظهر بعد تطبيقها
+
+بعض التحسينات تتطلب **إعادة تشغيل النظام** لتُطبَّق بالكامل. وإذا لم يعمل تعديل ما بعد إعادة التشغيل، فجرّب تطبيقه مجددًا أو راجع قسم التراجع للتأكد من حفظ التغيير.
+
+### ملف التراجع مفقود أو تالف
+
+تُخزَّن ملفات التراجع في `%LocalAppData%\optimizerDuck\Revert\`. وإذا حُذف ملف بالخطأ أو تلف، فيمكنك استعادته من نسخة احتياطية، أو إنشاء **نقطة استعادة للنظام** مسبقًا كخطة بديلة.
+
+### تحديثات ويندوز تعيد إعداداتي إلى ما كانت عليه
+
+تحديثات ويندوز الكبرى تعيد أحيانًا بعض قيم الريجستري وتهيئات الخدمات إلى الافتراضي. ببساطة أعد تطبيق تحسيناتك السابقة من التطبيق بعد أي تحديث كبير.
+
+### وجدت خللًا أو أريد اقتراح ميزة
+
+افتح [issue](https://github.com/itsfatduck/optimizerDuck/issues) على GitHub بأكبر قدر من التفاصيل: إصدار ويندوز لديك، وما طبّقته، وما الذي حدث. اقتراحات الميزات مرحّب بها أيضًا.
+
+---
+
+## التفاصيل التقنية
+
+- **إطار العمل**: WPF على .NET 10، باستخدام مكتبة WPF UI لتصميم Fluent
+- **نظام التراجع**: أربعة أنواع من خطوات التراجع (الريجستري، الخدمات، المهام المجدولة، الأوامر) مع حالة محفوظة بصيغة JSON وعمليات ملفات آمنة للخيوط
+- **السمات**: داكن (افتراضي) وفاتح وتباين عالٍ، مع دعم خلفية Mica
+- **بلا مثبّت**: يعمل كملف `.exe` واحد، لا يحتاج تثبيتًا
+- **نظام النسخ الاحتياطي**: نسخ احتياطي محلي قائم على المجلدات لكل تغيير، مع استعادة بنقرة واحدة
+- **الاكتشاف التلقائي**: تُكتشف فئات التحسينات والميزات تلقائيًا عبر الانعكاس (Reflection) والسمات المخصصة، دون تسجيل يدوي
+- **بلا قياس عن بُعد**: التطبيق لا يجمع أي بيانات عن المستخدم
+
+---
+
+## التوثيق
+
+### [التوثيق الرسمي](https://optimizerduck.vercel.app/docs/guides/getting-started)
+
+أدلة وتفاصيل التحسينات ونصائح الاستخدام.
+
+---
+
+## المساهمة
+
+تقارير الأخطاء والتحسينات الجديدة وتطوير التوثيق والترجمات، كلها مرحّب بها. راجع [CONTRIBUTING.md](./CONTRIBUTING.md) ([اليابانية](./CONTRIBUTING.ja-JP.md)، [التركية](./CONTRIBUTING.tr-TR.md)).
+
+---
+
+## المجتمع
+
+> [!TIP]
+> انضم إلى خادم Discord الخاص بنا للدعم والنصائح والنقاشات مع بقية المستخدمين والمساهمين.
+>
+> <a href="https://discord.gg/tDUBDCYw9Q"><img src="https://discord.com/api/guilds/1091675679994675240/widget.png?style=banner2" alt="Discord Banner 2"/></a>
+
+إذا ساعد optimizerDuck جهازك:
+
+- ⭐ ضع نجمة للمستودع
+- 💬 انضم إلى Discord للدعم
+- 🐞 أبلغ عن الأخطاء على GitHub
+- 🎁 ادعم المشروع [من هنا](https://optimizerduck.vercel.app/docs/contribute/support-me)
+
+### روابط
+
+- 🌐 [الموقع](https://optimizerduck.vercel.app/)
+- 📖 [التوثيق](https://optimizerduck.vercel.app/docs/guides/getting-started)
+- 💬 [Discord](https://discord.gg/tDUBDCYw9Q)
+- 🐞 [الأخطاء](https://github.com/itsfatduck/optimizerDuck/issues)
+
+تقارير الأخطاء واقتراحات الميزات والترجمات ومشاركة تجربتك، كلها تساعد المشروع.
+
+---
+
+## إخلاء المسؤولية
+
+يُقدَّم optimizerDuck **"كما هو"**، دون أي ضمان من أي نوع.
+
+باستخدامك هذه الأداة، فإنك توافق على أن المؤلفين غير مسؤولين عن عدم استقرار النظام أو فقدان البيانات أو المشاكل الناتجة عن برامج الطرف الثالث أو تعديلات المستخدم.
+
+أنشئ دائمًا **نقطة استعادة** قبل تطبيق التغييرات.
+
+> [!NOTE]
+> يعدّل optimizerDuck إعدادات النظام وريجستري ويندوز. الاستخدام على مسؤوليتك. نوصي بأخذ نسخة احتياطية من بياناتك المهمة وإنشاء نقطة استعادة قبل إجراء أي تغييرات.
+>
+> راجع [شروط الخدمة](./TERMS.md) و[سياسة الخصوصية](./PRIVACY.md) و[إخلاء المسؤولية](./DISCLAIMER.md) لمزيد من المعلومات.
+
+---
+
+## الرخصة
+
+</div>
+
+<div align="center">
+
+<a href="./LICENSE">
+<img src=".github/assets/gplv3.png" alt="GPL v3 License" title="GPL v3 License"/>
+</a>
+
+**[رخصة GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html)**<br>راجع [LICENSE](./LICENSE).
+
+</div>
+
+<div align="center">
+
+## شكرًا لجميع المساهمين
+
+[![Contributors](https://contrib.rocks/image?repo=itsfatduck/optimizerDuck)](https://github.com/itsfatduck/optimizerDuck/graphs/contributors)
+<br>
+[العودة إلى الأعلى](#optimizerduck)
+
+</div>

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -20,7 +20,7 @@
 
 **[Guía de Inicio](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Cómo Funciona](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [Preguntas Frecuentes](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | **Español** | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | **Español** | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Historial de Estrellas</summary>

--- a/README.fr-FR.md
+++ b/README.fr-FR.md
@@ -20,7 +20,7 @@
 
 **[Démarrage](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Comment ça marche](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | **Français** | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | **Français** | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Historique des étoiles</summary>

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -20,7 +20,7 @@
 
 **[はじめ方](https://optimizerduck.vercel.app/docs/guides/getting-started) | [仕組み](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [よくある質問](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | **日本語** | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | **日本語** | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ スター履歴</summary>

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -20,7 +20,7 @@
 
 **[시작하기](https://optimizerduck.vercel.app/docs/guides/getting-started) | [작동 원리](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | **한국어** | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | **한국어** | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ 스타 동향</summary>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Every star helps motivate future improvements.
 > | 🇵🇱 | Polish | Polski | [dudus2000](https://github.com/dudus2000) |
 > | 🇧🇷 | Portuguese (Brazil) | Português (Brasil) | [mhanelia](https://github.com/mhanelia) |
 > | 🇹🇷 | Turkish | Türkçe | [amhunter1](https://github.com/amhunter1) |
+> | 🇸🇦 | Arabic | العربية | [s5xx5s](https://github.com/s5xx5s) |
 > 
 > Want to add your language? See [CONTRIBUTING.md](./CONTRIBUTING.md) ([Japanese](./CONTRIBUTING.ja-JP.md), [Turkish](./CONTRIBUTING.tr-TR.md)).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 **[Getting Started](https://optimizerduck.vercel.app/docs/guides/getting-started) | [How It Works](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-**English** | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+**English** | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Star History</summary>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,7 +20,7 @@
 
 **[Primeiros Passos](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Como Funciona](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [Perguntas Frequentes (FAQ)](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | **Português (BR)** | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | **Português (BR)** | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Star History</summary>

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -20,7 +20,7 @@
 
 **[Начало работы](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Как это работает](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | **Русский** | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | **Русский** | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ История звёзд</summary>

--- a/README.tr-TR.md
+++ b/README.tr-TR.md
@@ -20,7 +20,7 @@
 
 **[Başlarken](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Nasıl Çalışır](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [SSS](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | **Türkçe**
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | **Türkçe** | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Yıldız Geçmişi</summary>

--- a/README.vi.md
+++ b/README.vi.md
@@ -20,7 +20,7 @@
 
 **[Bắt đầu](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Cách hoạt động](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [Câu hỏi thường gặp](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | **Tiếng Việt** | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | **Tiếng Việt** | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ Lịch sử Star</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
 
 **[快速上手](https://optimizerduck.vercel.app/docs/guides/getting-started) | [工作原理](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [常见问题](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | **简体中文** | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | **简体中文** | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ 项目星标趋势</summary>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -20,7 +20,7 @@
 
 **[開始使用](https://optimizerduck.vercel.app/docs/guides/getting-started) | [運作原理](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [常見問題](https://optimizerduck.vercel.app/docs/faq/general)**
 
-[English](README.md) | [Tiếng Việt](README.vi.md) | **繁體中文** | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | **繁體中文** | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md)
 
 <details>
 <summary>⭐ 星星歷史</summary>

--- a/optimizerDuck/Resources/Languages/Translations.ar-SA.resx
+++ b/optimizerDuck/Resources/Languages/Translations.ar-SA.resx
@@ -1,0 +1,1855 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+        Microsoft ResX Schema 
+        
+        Version 2.0
+        
+        The primary goals of this format is to allow a simple XML format 
+        that is mostly human readable. The generation and parsing of the 
+        various data types are done through the TypeConverter classes 
+        associated with the data types.
+        
+        Example:
+        
+        ... ado.net/XML headers & schema ...
+        <resheader name="resmimetype">text/microsoft-resx</resheader>
+        <resheader name="version">2.0</resheader>
+        <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+        <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+        <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+        <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+        <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+            <value>[base64 mime encoded serialized .NET Framework object]</value>
+        </data>
+        <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+            <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+            <comment>This is a comment</comment>
+        </data>
+                    
+        There are any number of "resheader" rows that contain simple 
+        name/value pairs.
+        
+        Each data row contains a name, and value. The row also contains a 
+        type or mimetype. Type corresponds to a .NET class that support 
+        text/value conversion through the TypeConverter architecture. 
+        Classes that don't support this are serialized and stored with the 
+        mimetype set.
+        
+        The mimetype is used for serialized objects, and tells the 
+        ResXResourceReader how to depersist the object. This is currently not 
+        extensible. For a given mimetype the value must be set accordingly:
+        
+        Note - application/x-microsoft.net.object.binary.base64 is the format 
+        that the ResXResourceWriter will generate, however the reader can 
+        read any of the formats listed below.
+        
+        mimetype: application/x-microsoft.net.object.binary.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+                : and then encoded with base64 encoding.
+        
+        mimetype: application/x-microsoft.net.object.soap.base64
+        value   : The object must be serialized with 
+                : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+                : and then encoded with base64 encoding.
+    
+        mimetype: application/x-microsoft.net.object.bytearray.base64
+        value   : The object must be serialized into a byte array 
+                : using a System.ComponentModel.TypeConverter
+                : and then encoded with base64 encoding.
+        -->
+  <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root" xmlns="">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
+            PublicKeyToken=b77a5c561934e089
+        </value>
+  </resheader>
+  <data name="Bloatware.Empty.Description" xml:space="preserve">
+    <value>لم يعثر ‎optimizerDuck‎ على أي حزم ‎AppX‎ قابلة للإزالة. فارغة تمامًا كالفراغ...</value>
+  </data>
+  <data name="Bloatware.Empty.Title" xml:space="preserve">
+    <value>لا توجد تطبيقات غير ضرورية ‎¯\_(ツ)_/¯‎</value>
+  </data>
+  <data name="Bloatware.Header.Description" xml:space="preserve">
+    <value>أدِر التطبيقات المثبّتة مسبقًا التي لا تحتاجها وأزلها</value>
+  </data>
+  <data name="Bloatware.Header.Title" xml:space="preserve">
+    <value>التطبيقات المرفقة</value>
+  </data>
+  <data name="Bloatware.Loading" xml:space="preserve">
+    <value>جارٍ البحث عن التطبيقات القابلة للإزالة...</value>
+  </data>
+  <data name="Bloatware.Loading.Hint" xml:space="preserve">
+    <value>قد يستغرق هذا لحظة بينما يفحص التطبيق الحزم المثبّتة.</value>
+  </data>
+  <data name="Bloatware.Menu.DeselectAllSafe" xml:space="preserve">
+    <value>إلغاء تحديد كل الآمن</value>
+  </data>
+  <data name="Bloatware.Menu.Refresh" xml:space="preserve">
+    <value>تحديث</value>
+  </data>
+  <data name="Bloatware.Menu.Remove" xml:space="preserve">
+    <value>إزالة ({0})</value>
+  </data>
+  <data name="Bloatware.Menu.SelectAllSafe" xml:space="preserve">
+    <value>تحديد كل الآمن</value>
+  </data>
+  <data name="Bloatware.Search.NoResults" xml:space="preserve">
+    <value>لا توجد نتائج. جرّب كلمة بحث أو تصفية مختلفة.</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Description" xml:space="preserve">
+    <value>راجع التطبيقات المحددة قبل الإزالة. تابع فقط إذا كنت متأكدًا.</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Message" xml:space="preserve">
+    <value>أنت على وشك إزالة: {0}</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.SelectedList" xml:space="preserve">
+    <value>التطبيقات المحددة</value>
+  </data>
+  <data name="BloatwareDialog.Confirmation.Title" xml:space="preserve">
+    <value>إزالة {0} تطبيق؟</value>
+  </data>
+  <data name="BloatwareDialog.Removing" xml:space="preserve">
+    <value>جارٍ إزالة {0} ({1}/{2})</value>
+  </data>
+  <data name="BloatwareDialog.Title" xml:space="preserve">
+    <value>جارٍ إزالة {0} حزمة ‎AppX‎</value>
+  </data>
+  <data name="Button.Accept" xml:space="preserve">
+    <value>موافقة</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>إلغاء</value>
+  </data>
+  <data name="Button.Clear" xml:space="preserve">
+    <value>مسح</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>إغلاق</value>
+  </data>
+  <data name="Button.Ok" xml:space="preserve">
+    <value>موافق</value>
+  </data>
+  <data name="Button.Open" xml:space="preserve">
+    <value>فتح</value>
+  </data>
+  <data name="Button.Retry" xml:space="preserve">
+    <value>إعادة المحاولة</value>
+  </data>
+  <data name="Button.Skip" xml:space="preserve">
+    <value>تخطّي</value>
+  </data>
+  <data name="Button.ViewLatestRelease" xml:space="preserve">
+    <value>عرض أحدث إصدار</value>
+  </data>
+  <data name="Common.AppliedDaysAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} يوم</value>
+  </data>
+  <data name="Common.AppliedHoursAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} ساعة</value>
+  </data>
+  <data name="Common.AppliedJustNow" xml:space="preserve">
+    <value>طُبِّق للتو</value>
+  </data>
+  <data name="Common.AppliedMinutesAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} دقيقة</value>
+  </data>
+  <data name="Common.AppliedMonthsAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} شهر</value>
+  </data>
+  <data name="Common.AppliedSecondsAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} ثانية</value>
+  </data>
+  <data name="Common.AppliedYearsAgo" xml:space="preserve">
+    <value>طُبِّق منذ {0} سنة</value>
+  </data>
+  <data name="Common.Cancel" xml:space="preserve">
+    <value>إلغاء</value>
+  </data>
+  <data name="Common.Delete" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+  <data name="Common.Empty" xml:space="preserve">
+    <value>فارغ</value>
+  </data>
+  <data name="Common.Filter" xml:space="preserve">
+    <value>تصفية</value>
+  </data>
+  <data name="Common.Filter.All" xml:space="preserve">
+    <value>الكل</value>
+  </data>
+  <data name="Common.OpenFolder" xml:space="preserve">
+    <value>فتح المجلد</value>
+  </data>
+  <data name="Common.Other" xml:space="preserve">
+    <value>أخرى</value>
+  </data>
+  <data name="Common.Recommendation.Depends" xml:space="preserve">
+    <value>حسب الحالة</value>
+  </data>
+  <data name="Common.Recommendation.Experimental" xml:space="preserve">
+    <value>تجريبي</value>
+  </data>
+  <data name="Common.Recommendation.Off" xml:space="preserve">
+    <value>غير موصى به</value>
+  </data>
+  <data name="Common.Recommendation.On" xml:space="preserve">
+    <value>موصى به</value>
+  </data>
+  <data name="Common.Search.Placeholder" xml:space="preserve">
+    <value>بحث...</value>
+  </data>
+  <data name="Common.SortBy" xml:space="preserve">
+    <value>ترتيب حسب</value>
+  </data>
+  <data name="Common.SortBy.Default" xml:space="preserve">
+    <value>الافتراضي</value>
+  </data>
+  <data name="Common.SortBy.Name" xml:space="preserve">
+    <value>الاسم</value>
+  </data>
+  <data name="Common.SortBy.Path" xml:space="preserve">
+    <value>المسار</value>
+  </data>
+  <data name="Common.SortBy.Publisher" xml:space="preserve">
+    <value>الناشر</value>
+  </data>
+  <data name="Common.SortBy.Risk" xml:space="preserve">
+    <value>الخطورة</value>
+  </data>
+  <data name="Common.SortBy.Size" xml:space="preserve">
+    <value>الحجم</value>
+  </data>
+  <data name="Common.SortBy.State" xml:space="preserve">
+    <value>الحالة</value>
+  </data>
+  <data name="Common.SortBy.Status" xml:space="preserve">
+    <value>الحالة</value>
+  </data>
+  <data name="Common.Status.Applied" xml:space="preserve">
+    <value>مُطبَّق</value>
+  </data>
+  <data name="Common.Toggle.Off" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="Common.Toggle.On" xml:space="preserve">
+    <value>تشغيل</value>
+  </data>
+  <data name="Common.Unknown" xml:space="preserve">
+    <value>غير معروف</value>
+  </data>
+  <data name="Customize.Description" xml:space="preserve">
+    <value>خصّص إعدادات ويندوز وتفضيلاته</value>
+  </data>
+  <data name="Customize.Desktop.Description" xml:space="preserve">
+    <value>إعدادات أيقونات سطح المكتب والاختصارات</value>
+  </data>
+  <data name="Customize.Desktop.Name" xml:space="preserve">
+    <value>سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.Section.Behaviors" xml:space="preserve">
+    <value>سلوك الاختصارات</value>
+  </data>
+  <data name="Customize.Desktop.Section.Icons" xml:space="preserve">
+    <value>أيقونات سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Description" xml:space="preserve">
+    <value>يُظهر أو يخفي سهم الاختصار المتراكب على أيقونات سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShortcutArrow.Name" xml:space="preserve">
+    <value>سهم الاختصار</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Description" xml:space="preserve">
+    <value>يعرض أيقونة لوحة التحكم على سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowControlPanel.Name" xml:space="preserve">
+    <value>لوحة التحكم</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Description" xml:space="preserve">
+    <value>يُظهر أو يخفي جميع أيقونات سطح المكتب دفعةً واحدة</value>
+  </data>
+  <data name="Customize.Desktop.ShowDesktopIcons.Name" xml:space="preserve">
+    <value>أيقونات سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Description" xml:space="preserve">
+    <value>يعرض أيقونة الشبكة على سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowNetwork.Name" xml:space="preserve">
+    <value>الشبكة</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Description" xml:space="preserve">
+    <value>يعرض أيقونة سلة المحذوفات على سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowRecycleBin.Name" xml:space="preserve">
+    <value>سلة المحذوفات</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Description" xml:space="preserve">
+    <value>يعرض أيقونة «هذا الكمبيوتر» على سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowThisPc.Name" xml:space="preserve">
+    <value>هذا الكمبيوتر</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Description" xml:space="preserve">
+    <value>يعرض مجلد ملف تعريف المستخدم كأيقونة على سطح المكتب</value>
+  </data>
+  <data name="Customize.Desktop.ShowUserFiles.Name" xml:space="preserve">
+    <value>ملفات المستخدم</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Description" xml:space="preserve">
+    <value>يتحكم في التسجيل التلقائي للألعاب في الخلفية (‎Game DVR‎) والتقاط التطبيقات.</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Name" xml:space="preserve">
+    <value>التسجيل في الخلفية (DVR)</value>
+  </data>
+  <data name="Customize.Gaming.BackgroundRecording.Recommendation.Reason" xml:space="preserve">
+    <value>تعطيل التسجيل في الخلفية يمنع ‎DVR‎ من التقاط اللعب بصمت، ما يوفر موارد المعالج ودورات الكتابة على القرص.</value>
+  </data>
+  <data name="Customize.Gaming.Description" xml:space="preserve">
+    <value>إعدادات العرض والإدخال والتسجيل المتعلقة بالألعاب</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Description" xml:space="preserve">
+    <value>إعداد تحسينات ملء الشاشة المعتمدة على ‎DWM‎ في ويندوز.</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Name" xml:space="preserve">
+    <value>تحسينات ملء الشاشة</value>
+  </data>
+  <data name="Customize.Gaming.FullscreenOptimizations.Recommendation.Reason" xml:space="preserve">
+    <value>عطّله إذا واجهت تقطّعًا داخل اللعبة أو تأخيرًا في الاستجابة أو شاشات سوداء (خصوصًا في ألعاب التصويب التنافسية).</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Description" xml:space="preserve">
+    <value>يتحكم في طبقات ‎Xbox Game Bar‎ ولوحة بدء التشغيل والميزات المرتبطة بها في الخلفية.</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Name" xml:space="preserve">
+    <value>‎Xbox Game Bar‎</value>
+  </data>
+  <data name="Customize.Gaming.GameBar.Recommendation.Reason" xml:space="preserve">
+    <value>تعطيل ‎Game Bar‎ يحرر موارد النظام ويمنع الطبقات العاملة في الخلفية من التداخل مع ألعابك.</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Description" xml:space="preserve">
+    <value>وضع الألعاب في ويندوز، ويؤثر على عمليات الألعاب وسلوك تحديثات ويندوز.</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Name" xml:space="preserve">
+    <value>وضع الألعاب</value>
+  </data>
+  <data name="Customize.Gaming.GameMode.Recommendation.Reason" xml:space="preserve">
+    <value>يعطي وضع الألعاب الأولوية تلقائيًا لعمليات اللعبة ويؤجل إشعارات تحديثات ويندوز أثناء اللعب للحصول على أداء أكثر سلاسة.</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Description" xml:space="preserve">
+    <value>وضع جدولة ذاكرة الفيديو في معالج الرسومات. يتطلب تعريفًا متوافقًا.</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Name" xml:space="preserve">
+    <value>جدولة معالج الرسومات المُسرَّعة بالعتاد</value>
+  </data>
+  <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
+    <value>تنقل جدولة معالج الرسومات إدارة الإطارات من المعالج إلى كرت الشاشة، ما يقلل زمن استجابة العرض ويحسّن انتظام الإطارات.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Description" xml:space="preserve">
+    <value>إعداد تسريع الفأرة في ويندوز لحركة المؤشر.</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Name" xml:space="preserve">
+    <value>تسريع الفأرة</value>
+  </data>
+  <data name="Customize.Gaming.MouseAcceleration.Recommendation.Reason" xml:space="preserve">
+    <value>تعطيل التسريع يمنحك إدخالًا خطيًا خامًا للفأرة، ما يحسّن دقة التصويب وثبات الذاكرة العضلية.</value>
+  </data>
+  <data name="Customize.Gaming.Name" xml:space="preserve">
+    <value>الألعاب</value>
+  </data>
+  <data name="Customize.Gaming.Section.Display" xml:space="preserve">
+    <value>العرض</value>
+  </data>
+  <data name="Customize.Gaming.Section.GameSettings" xml:space="preserve">
+    <value>إعدادات الألعاب</value>
+  </data>
+  <data name="Customize.Gaming.Section.Input" xml:space="preserve">
+    <value>الإدخال</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Description" xml:space="preserve">
+    <value>دمج بحث الويب من ‎Bing‎ في نتائج بحث ويندوز وقائمة ابدأ.</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Name" xml:space="preserve">
+    <value>بحث ‎Bing‎</value>
+  </data>
+  <data name="Customize.Preferences.BingSearch.Recommendation.Reason" xml:space="preserve">
+    <value>إيقاف بحث ‎Bing‎ يمنع استعلامات الويب من ازدحام نتائج البحث المحلية ويحسّن سرعة البحث.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Description" xml:space="preserve">
+    <value>قائمة السياق بنمط ويندوز 10 على ويندوز 11.</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Name" xml:space="preserve">
+    <value>قائمة السياق الكلاسيكية</value>
+  </data>
+  <data name="Customize.Preferences.ClassicContextMenu.Recommendation.Reason" xml:space="preserve">
+    <value>تعرض القائمة الكلاسيكية كل الخيارات دفعةً واحدة دون النقرة الإضافية اللازمة لتوسيع قائمة ويندوز 11 المختصرة.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Description" xml:space="preserve">
+    <value>سجل الحافظة لعدة عناصر منسوخة يمكن الوصول إليه بمفتاحَي ‎Win+V‎.</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Name" xml:space="preserve">
+    <value>سجل الحافظة</value>
+  </data>
+  <data name="Customize.Preferences.ClipboardHistory.Recommendation.Reason" xml:space="preserve">
+    <value>يتيح سجل الحافظة استرجاع عدة نسخ سابقة عبر ‎Win+V‎، ما يسرّع مهام النسخ واللصق المتكررة.</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Description" xml:space="preserve">
+    <value>الوضع الداكن لتطبيقات النظام والإعدادات وعناصر الواجهة.</value>
+  </data>
+  <data name="Customize.Preferences.DarkMode.Name" xml:space="preserve">
+    <value>الوضع الداكن</value>
+  </data>
+  <data name="Customize.Preferences.Description" xml:space="preserve">
+    <value>خصّص إعدادات المظهر والتفاعل</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Description" xml:space="preserve">
+    <value>يقلل المسافات بين العناصر في مستكشف الملفات لعرض أكثف.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerCompactMode.Name" xml:space="preserve">
+    <value>العرض المضغوط في المستكشف</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Description" xml:space="preserve">
+    <value>يعرض مربعات اختيار عند تحديد العناصر في مستكشف الملفات.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerItemCheckboxes.Name" xml:space="preserve">
+    <value>مربعات اختيار العناصر</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Description" xml:space="preserve">
+    <value>يتحكم في إشعارات ‎OneDrive‎ وموفّري المزامنة السحابية داخل مستكشف الملفات.</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Name" xml:space="preserve">
+    <value>إشعارات المزامنة في المستكشف</value>
+  </data>
+  <data name="Customize.Preferences.ExplorerSyncNotifications.Recommendation.Reason" xml:space="preserve">
+    <value>تعطيل إشعارات المزامنة يوقف نوافذ ‎OneDrive‎ المنبثقة عن مقاطعة تصفح الملفات.</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Description" xml:space="preserve">
+    <value>إعداد الموقع الافتراضي لمستكشف الملفات (هذا الكمبيوتر أو الوصول السريع).</value>
+  </data>
+  <data name="Customize.Preferences.LaunchToThisPc.Name" xml:space="preserve">
+    <value>الفتح على «هذا الكمبيوتر»</value>
+  </data>
+  <data name="Customize.Preferences.Name" xml:space="preserve">
+    <value>التفضيلات</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Description" xml:space="preserve">
+    <value>يتحكم في طريقة عرض زر البحث ومربعه على شريط المهام.</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Name" xml:space="preserve">
+    <value>عرض مربع البحث</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.Hidden" xml:space="preserve">
+    <value>مخفي</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.Icon" xml:space="preserve">
+    <value>أيقونة فقط</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.IconAndLabel" xml:space="preserve">
+    <value>أيقونة مع نص</value>
+  </data>
+  <data name="Customize.Preferences.SearchBoxTaskbarMode.Options.SearchBox" xml:space="preserve">
+    <value>مربع بحث</value>
+  </data>
+  <data name="Customize.Preferences.Section.Appearance" xml:space="preserve">
+    <value>المظهر</value>
+  </data>
+  <data name="Customize.Preferences.Section.Explorer" xml:space="preserve">
+    <value>مستكشف الملفات</value>
+  </data>
+  <data name="Customize.Preferences.Section.Taskbar" xml:space="preserve">
+    <value>شريط المهام</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Description" xml:space="preserve">
+    <value>يعرض امتدادات الملفات (مثل ‎.txt‎ و‎.exe‎) في مستكشف الملفات.</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Name" xml:space="preserve">
+    <value>إظهار امتدادات الملفات</value>
+  </data>
+  <data name="Customize.Preferences.ShowFileExtensions.Recommendation.Reason" xml:space="preserve">
+    <value>إظهار الامتدادات يسهّل اكتشاف أنواع الملفات المشبوهة ويمنع البرمجيات الخبيثة من التخفي خلف أيقونات مزيفة.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Description" xml:space="preserve">
+    <value>يعرض الملفات والمجلدات المخفية في مستكشف الملفات.</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Name" xml:space="preserve">
+    <value>إظهار الملفات المخفية</value>
+  </data>
+  <data name="Customize.Preferences.ShowHiddenFiles.Recommendation.Reason" xml:space="preserve">
+    <value>تحتوي الملفات المخفية على بيانات نظام وإعدادات قد تحتاج إدارتها؛ إظهارها يمنحك رؤية كاملة لنظامك.</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Description" xml:space="preserve">
+    <value>يعرض الثواني في ساعة شريط المهام.</value>
+  </data>
+  <data name="Customize.Preferences.ShowSecondsInSystemClock.Name" xml:space="preserve">
+    <value>الثواني في ساعة النظام</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Description" xml:space="preserve">
+    <value>يتحكم في قائمة تخطيطات الإرساء التي تظهر عند تمرير المؤشر فوق زر التكبير.</value>
+  </data>
+  <data name="Customize.Preferences.SnapAssistFlyout.Name" xml:space="preserve">
+    <value>قائمة تخطيطات الإرساء</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Description" xml:space="preserve">
+    <value>يتحكم في تلميحات ويندوز واقتراحات التطبيقات داخل لوحة الإعدادات.</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Name" xml:space="preserve">
+    <value>اقتراحات النظام</value>
+  </data>
+  <data name="Customize.Preferences.SystemSuggestions.Recommendation.Reason" xml:space="preserve">
+    <value>إيقاف اقتراحات النظام يمنع ويندوز من ترشيح تطبيقات وإعدادات لم تطلبها.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Description" xml:space="preserve">
+    <value>يبدّل محاذاة شريط المهام بين الوسط واليسار.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Name" xml:space="preserve">
+    <value>محاذاة شريط المهام</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Center" xml:space="preserve">
+    <value>الوسط</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarAlignment.Options.Left" xml:space="preserve">
+    <value>اليسار</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Description" xml:space="preserve">
+    <value>يضيف خيار «إنهاء المهمة» إلى قائمة النقر الأيمن على شريط المهام لإنهاء العمليات بسرعة.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Name" xml:space="preserve">
+    <value>إنهاء المهمة من شريط المهام</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarEndTask.Recommendation.Reason" xml:space="preserve">
+    <value>يتيح لك «إنهاء المهمة» من شريط المهام إغلاق التطبيقات المتوقفة فورًا دون فتح إدارة المهام.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarLastActiveClick.Description" xml:space="preserve">
+    <value>النقر على أيقونة في شريط المهام يفتح آخر نافذة نشطة لذلك التطبيق مباشرة.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarLastActiveClick.Name" xml:space="preserve">
+    <value>النقر على آخر نافذة نشطة</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Description" xml:space="preserve">
+    <value>يتحكم في إظهار زر عرض المهام على شريط المهام.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarTaskViewButton.Name" xml:space="preserve">
+    <value>زر عرض المهام</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Description" xml:space="preserve">
+    <value>يتحكم في إظهار زر الأدوات المصغّرة على شريط المهام.</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Name" xml:space="preserve">
+    <value>الأدوات المصغّرة</value>
+  </data>
+  <data name="Customize.Preferences.TaskbarWidgets.Recommendation.Reason" xml:space="preserve">
+    <value>إيقاف الأدوات المصغّرة يزيل خدمة الويب التي تجلب الأخبار والطقس في الخلفية، ما يقلل استهلاك الشبكة والذاكرة أثناء الخمول.</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Description" xml:space="preserve">
+    <value>يتحكم في الإشعارات المنبثقة وإشعارات شاشة القفل.</value>
+  </data>
+  <data name="Customize.Preferences.ToastNotifications.Name" xml:space="preserve">
+    <value>الإشعارات المنبثقة</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Description" xml:space="preserve">
+    <value>هزّ نافذة لتصغير جميع النوافذ المفتوحة الأخرى.</value>
+  </data>
+  <data name="Customize.Preferences.WindowShake.Name" xml:space="preserve">
+    <value>هزّ النافذة</value>
+  </data>
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Description" xml:space="preserve">
+    <value>يسمح بتثبيت جميع تطبيقات متجر ويندوز الموثوقة دون الحاجة إلى تفعيل وضع المطوّر.</value>
+  </data>
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Name" xml:space="preserve">
+    <value>السماح بجميع التطبيقات الموثوقة</value>
+  </data>
+  <data name="Customize.SystemFeatures.AllowAllTrustedApps.Recommendation.Reason" xml:space="preserve">
+    <value>السماح بجميع التطبيقات الموثوقة يتيح التثبيت الجانبي دون وضع المطوّر؛ وتعطيله يقصر التثبيت على ‎Microsoft Store‎.</value>
+  </data>
+  <data name="Customize.SystemFeatures.Description" xml:space="preserve">
+    <value>ميزات النظام الأساسية وسلوكياته</value>
+  </data>
+  <data name="Customize.SystemFeatures.DeveloperMode.Description" xml:space="preserve">
+    <value>يفعّل وضع المطوّر في ويندوز للتثبيت الجانبي للتطبيقات وبوابة الأجهزة وخادم ‎SSH‎ وميزات التطوير.</value>
+  </data>
+  <data name="Customize.SystemFeatures.DeveloperMode.Name" xml:space="preserve">
+    <value>وضع المطوّر</value>
+  </data>
+  <data name="Customize.SystemFeatures.DeveloperMode.Recommendation.Reason" xml:space="preserve">
+    <value>يتيح وضع المطوّر التثبيت الجانبي وميزات التشخيص الضرورية لتطوير التطبيقات وتصحيحها.</value>
+  </data>
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Description" xml:space="preserve">
+    <value>يفعّل دعم المسارات الطويلة في ‎Win32‎ داخل مستكشف الملفات، ما يسمح بمسارات تتجاوز الحد التقليدي البالغ 260 حرفًا.</value>
+  </data>
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Name" xml:space="preserve">
+    <value>دعم المسارات الطويلة (أكثر من 260 حرفًا)</value>
+  </data>
+  <data name="Customize.SystemFeatures.LongPathsEnabled.Recommendation.Reason" xml:space="preserve">
+    <value>دعم المسارات الطويلة يمنع أخطاء الوصول إلى الملفات عند العمل مع مجلدات متداخلة بعمق أو مشاريع ذات أسماء طويلة.</value>
+  </data>
+  <data name="Customize.SystemFeatures.Name" xml:space="preserve">
+    <value>النظام</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Description" xml:space="preserve">
+    <value>حالة مفتاح ‎NumLock‎ في شاشة تسجيل الدخول إلى ويندوز.</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
+    <value>تفعيل ‎NumLock‎ عند الإقلاع</value>
+  </data>
+  <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
+    <value>تفعيل ‎NumLock‎ عند الإقلاع يضمن جاهزية لوحة الأرقام فور تسجيل الدخول، ويوفر عناء تفعيلها يدويًا في كل مرة.</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Developer" xml:space="preserve">
+    <value>المطوّرون</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
+    <value>إعدادات الإدخال</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
+    <value>إعدادات الطاقة</value>
+  </data>
+  <data name="Customize.SystemFeatures.ShowBatteryPercentage.Description" xml:space="preserve">
+    <value>يعرض نسبة البطارية بجوار أيقونة البطارية في منطقة الإعلام.</value>
+  </data>
+  <data name="Customize.SystemFeatures.ShowBatteryPercentage.Name" xml:space="preserve">
+    <value>إظهار نسبة البطارية</value>
+  </data>
+  <data name="Customize.Title" xml:space="preserve">
+    <value>التخصيص</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Description" xml:space="preserve">
+    <value>انضم إلى مجتمع Discord للحصول على الدعم أو للعب معنا</value>
+  </data>
+  <data name="Dashboard.Actions.Discord.Title" xml:space="preserve">
+    <value>مجتمع Discord</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Description" xml:space="preserve">
+    <value>استعرض المشروع وراجعه وساهم فيه عبر GitHub</value>
+  </data>
+  <data name="Dashboard.Actions.GitHub.Title" xml:space="preserve">
+    <value>مستودع GitHub</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Description" xml:space="preserve">
+    <value>ضع نجمة للمستودع على GitHub، أو شاركه مع أصدقائك، أو تبرّع — كل مساهمة تساعد المشروع على النمو!</value>
+  </data>
+  <data name="Dashboard.Actions.SupportMe.Title" xml:space="preserve">
+    <value>ساهم</value>
+  </data>
+  <data name="Dashboard.Header.Menu.Refresh" xml:space="preserve">
+    <value>تحديث</value>
+  </data>
+  <data name="Dashboard.Header.Menu.RunTaskManager" xml:space="preserve">
+    <value>إدارة المهام</value>
+  </data>
+  <data name="Dashboard.Header.Title" xml:space="preserve">
+    <value>لوحة المعلومات</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Cores" xml:space="preserve">
+    <value>{0} نواة</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Cpu.Threads" xml:space="preserve">
+    <value>{0} مسار تنفيذ</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Gpu.More" xml:space="preserve">
+    <value>‎+ {0} معالج رسومات إضافي</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Header" xml:space="preserve">
+    <value>معلومات النظام</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Loading" xml:space="preserve">
+    <value>جارٍ جلب معلومات النظام...</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.Build" xml:space="preserve">
+    <value>الإصدار الداخلي (Build) {0}</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Desktop" xml:space="preserve">
+    <value>كمبيوتر مكتبي</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Os.DeviceType.Laptop" xml:space="preserve">
+    <value>كمبيوتر محمول</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Available" xml:space="preserve">
+    <value>{0} GB متاح</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Modules" xml:space="preserve">
+    <value>{0} وحدة</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Ram.Used" xml:space="preserve">
+    <value>{0} GB مستخدم</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.DiskInfo" xml:space="preserve">
+    <value>مستخدم {0} GB من {1} GB (متاح {2} GB)</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.Header" xml:space="preserve">
+    <value>التخزين</value>
+  </data>
+  <data name="Dashboard.SystemInfo.Storage.System" xml:space="preserve">
+    <value>النظام</value>
+  </data>
+  <data name="Dashboard.UpdateInfoBar.Message" xml:space="preserve">
+    <value>الإصدار optimizerDuck (v{0}) متوفر!
+حدّث الآن للاستفادة من أحدث المزايا والتحسينات وإصلاحات الأخطاء.</value>
+  </data>
+  <data name="Dialog.AreYouSure.Title" xml:space="preserve">
+    <value>هل تريد المتابعة فعلًا؟</value>
+  </data>
+  <data name="Dialog.PendingChanges.CloseButton" xml:space="preserve">
+    <value>الخروج على أي حال</value>
+  </data>
+  <data name="Dialog.PendingChanges.Content" xml:space="preserve">
+    <value>بعض التغييرات تتطلب إعادة تشغيل لتصبح فعّالة. ماذا تريد أن تفعل قبل الخروج؟</value>
+  </data>
+  <data name="Dialog.PendingChanges.PrimaryButton" xml:space="preserve">
+    <value>إعادة تشغيل الجهاز</value>
+  </data>
+  <data name="Dialog.PendingChanges.SecondaryButton" xml:space="preserve">
+    <value>إعادة تشغيل مستكشف الملفات</value>
+  </data>
+  <data name="Dialog.PendingChanges.Title" xml:space="preserve">
+    <value>تطبيق التغييرات</value>
+  </data>
+  <data name="DiskCleanup.Button.Clean" xml:space="preserve">
+    <value>تنظيف</value>
+  </data>
+  <data name="DiskCleanup.Button.CleanSelected" xml:space="preserve">
+    <value>تنظيف المحدد ({0})</value>
+  </data>
+  <data name="DiskCleanup.Button.DeselectAll" xml:space="preserve">
+    <value>إلغاء تحديد الكل</value>
+  </data>
+  <data name="DiskCleanup.Button.Scan" xml:space="preserve">
+    <value>فحص</value>
+  </data>
+  <data name="DiskCleanup.Button.SelectAll" xml:space="preserve">
+    <value>تحديد الكل</value>
+  </data>
+  <data name="DiskCleanup.Complete.Message" xml:space="preserve">
+    <value>تم تحرير {0}‎ من مساحة القرص خلال {1}</value>
+  </data>
+  <data name="DiskCleanup.Complete.Title" xml:space="preserve">
+    <value>اكتمل التنظيف</value>
+  </data>
+  <data name="DiskCleanup.Dialog.Confirmation.SingleItem" xml:space="preserve">
+    <value>أنت على وشك حذف {0} ({1}). يُرجى التأكيد.</value>
+  </data>
+  <data name="DiskCleanup.Dialog.Confirmation.SingleTitle" xml:space="preserve">
+    <value>تنظيف عنصر</value>
+  </data>
+  <data name="DiskCleanup.Dialog.Confirmation.Summary" xml:space="preserve">
+    <value>أنت على وشك حذف {0}‎ من {1} عنصر ({2} ملف). يُرجى مراجعة العناصر أدناه.</value>
+  </data>
+  <data name="DiskCleanup.Dialog.Confirmation.Title" xml:space="preserve">
+    <value>تنظيف {0} عنصر محدد</value>
+  </data>
+  <data name="DiskCleanup.Dialog.Confirmation.Warning" xml:space="preserve">
+    <value>ستُحذف الملفات نهائيًا. لا يمكن التراجع عن هذا الإجراء.</value>
+  </data>
+  <data name="DiskCleanup.EmptySize" xml:space="preserve">
+    <value>فارغ</value>
+  </data>
+  <data name="DiskCleanup.Error.Message" xml:space="preserve">
+    <value>تعذّر حذف بعض الملفات. قد تكون قيد الاستخدام من عملية أخرى.</value>
+  </data>
+  <data name="DiskCleanup.Error.Title" xml:space="preserve">
+    <value>خطأ في التنظيف</value>
+  </data>
+  <data name="DiskCleanup.FilesCount" xml:space="preserve">
+    <value>{0} ملف</value>
+  </data>
+  <data name="DiskCleanup.Header.Description" xml:space="preserve">
+    <value>حرّر مساحة على القرص بإزالة الملفات المؤقتة والذاكرة المخبّأة</value>
+  </data>
+  <data name="DiskCleanup.Header.Title" xml:space="preserve">
+    <value>تنظيف القرص</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports" xml:space="preserve">
+    <value>تقارير الأخطاء</value>
+  </data>
+  <data name="DiskCleanup.Item.ErrorReports.Description" xml:space="preserve">
+    <value>تقارير أخطاء ويندوز وملفات تفريغ الأعطال</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation" xml:space="preserve">
+    <value>تثبيت ويندوز السابق (‎Windows.old‎)</value>
+  </data>
+  <data name="DiskCleanup.Item.OldWindowsInstallation.Description" xml:space="preserve">
+    <value>ملفات تثبيت ويندوز السابقة المحفوظة بعد تحديث أو ترقية كبرى</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch" xml:space="preserve">
+    <value>ملفات التحميل المسبق (Prefetch)</value>
+  </data>
+  <data name="DiskCleanup.Item.Prefetch.Description" xml:space="preserve">
+    <value>بيانات التحميل المسبق للتطبيقات المستخدمة لتسريع فتحها</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin" xml:space="preserve">
+    <value>سلة المحذوفات</value>
+  </data>
+  <data name="DiskCleanup.Item.RecycleBin.Description" xml:space="preserve">
+    <value>الملفات المحذوفة التي ما زالت مخزّنة في سلة المحذوفات</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp" xml:space="preserve">
+    <value>ملفات النظام المؤقتة</value>
+  </data>
+  <data name="DiskCleanup.Item.SystemTemp.Description" xml:space="preserve">
+    <value>الملفات المؤقتة الخاصة بنظام ويندوز</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles" xml:space="preserve">
+    <value>الملفات المؤقتة</value>
+  </data>
+  <data name="DiskCleanup.Item.TempFiles.Description" xml:space="preserve">
+    <value>ملفات المستخدم المؤقتة التي تنشئها التطبيقات (باستثناء مجلد ‎.net‎ المؤقت)</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails" xml:space="preserve">
+    <value>ذاكرة الصور المصغّرة</value>
+  </data>
+  <data name="DiskCleanup.Item.Thumbnails.Description" xml:space="preserve">
+    <value>صور مصغّرة مخزّنة مؤقتًا لمعاينات الملفات في مستكشف الملفات</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate" xml:space="preserve">
+    <value>ذاكرة تحديثات ويندوز</value>
+  </data>
+  <data name="DiskCleanup.Item.WindowsUpdate.Description" xml:space="preserve">
+    <value>ملفات تحديثات ويندوز المُنزَّلة التي لم تعد هناك حاجة إليها</value>
+  </data>
+  <data name="DiskCleanup.ItemsAndFilesSelected" xml:space="preserve">
+    <value>محدد {0}‎ • {1} عنصر • {2} ملف</value>
+  </data>
+  <data name="DiskCleanup.ItemsSelected" xml:space="preserve">
+    <value>{0}‎ (تم تحديد {1} عنصر)</value>
+  </data>
+  <data name="DiskCleanup.Loading" xml:space="preserve">
+    <value>جارٍ تحميل عناصر التنظيف...</value>
+  </data>
+  <data name="DiskCleanup.Scanning" xml:space="preserve">
+    <value>جارٍ الفحص...</value>
+  </data>
+  <data name="DiskCleanup.TotalSpace" xml:space="preserve">
+    <value>إجمالي المساحة القابلة للاستعادة</value>
+  </data>
+  <data name="LegalDialog.Intro.Review" xml:space="preserve">
+    <value>يُرجى أخذ لحظة لمراجعة المستندات التالية. بمتابعتك فإنك توافق على هذه الشروط.</value>
+  </data>
+  <data name="LegalDialog.Intro.Safety" xml:space="preserve">
+    <value>لضمان الشفافية وسلامتك، قد يعدّل ‎optimizerDuck‎ بعض إعدادات النظام وتهيئات الريجستري.</value>
+  </data>
+  <data name="LegalDialog.Intro.ThankYou" xml:space="preserve">
+    <value>شكرًا لاختيارك ‎optimizerDuck‎.</value>
+  </data>
+  <data name="LegalDialog.Link.Disclaimer" xml:space="preserve">
+    <value>إخلاء المسؤولية</value>
+  </data>
+  <data name="LegalDialog.Link.PrivacyPolicy" xml:space="preserve">
+    <value>سياسة الخصوصية</value>
+  </data>
+  <data name="LegalDialog.Link.TermsOfService" xml:space="preserve">
+    <value>شروط الخدمة</value>
+  </data>
+  <data name="LegalDialog.Title" xml:space="preserve">
+    <value>الإقرار القانوني</value>
+  </data>
+  <data name="LegalDialog.Warning.Message" xml:space="preserve">
+    <value>نوصي بإنشاء نسخة احتياطية قبل تطبيق أي تغييرات.</value>
+  </data>
+  <data name="LegalDialog.Warning.Title" xml:space="preserve">
+    <value>الاستخدام على مسؤوليتك</value>
+  </data>
+  <data name="Optimization.Apply.Completed" xml:space="preserve">
+    <value>اكتمل</value>
+  </data>
+  <data name="Optimization.Apply.Error.Failed" xml:space="preserve">
+    <value>فشل تطبيق {0}.</value>
+  </data>
+  <data name="Optimization.Apply.Error.FailedWithSteps" xml:space="preserve">
+    <value>طُبِّق {0} مع فشل {1} خطوة.</value>
+  </data>
+  <data name="Optimization.Apply.Error.Unknown" xml:space="preserve">
+    <value>نتيجة غير معروفة لـ {0}.</value>
+  </data>
+  <data name="Optimization.Apply.Processing" xml:space="preserve">
+    <value>جارٍ تطبيق التغييرات...</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Error.Title" xml:space="preserve">
+    <value>تعذّر تطبيق التحسين بالكامل</value>
+  </data>
+  <data name="Optimization.Apply.Snackbar.Success.Title" xml:space="preserve">
+    <value>طُبِّق التحسين بنجاح</value>
+  </data>
+  <data name="Optimization.Apply.Success" xml:space="preserve">
+    <value>تم تطبيق {0} بنجاح.</value>
+  </data>
+  <data name="Optimization.Retry.Processing" xml:space="preserve">
+    <value>جارٍ إعادة محاولة الخطوات الفاشلة...</value>
+  </data>
+  <data name="Optimization.RetryStep.Processing" xml:space="preserve">
+    <value>جارٍ إعادة محاولة خطوة {0} ({1}/{2} خطوة)</value>
+  </data>
+  <data name="Optimization.Revert.Error.Failed" xml:space="preserve">
+    <value>فشل التراجع عن {0}.</value>
+  </data>
+  <data name="Optimization.Revert.Error.FailedWithSteps" xml:space="preserve">
+    <value>تم التراجع عن {0} مع فشل {1} خطوة.</value>
+  </data>
+  <data name="Optimization.Revert.ExecutingStep" xml:space="preserve">
+    <value>تنفيذ خطوة التراجع: {0}/{1} ({2})</value>
+  </data>
+  <data name="Optimization.Revert.Reverting" xml:space="preserve">
+    <value>جارٍ التراجع...</value>
+  </data>
+  <data name="Optimization.Revert.Snackbar.Error.Title" xml:space="preserve">
+    <value>تعذّر التراجع عن التحسين</value>
+  </data>
+  <data name="Optimization.Revert.Snackbar.Success.Title" xml:space="preserve">
+    <value>تم التراجع عن التحسين بنجاح</value>
+  </data>
+  <data name="Optimization.Revert.StepDescription" xml:space="preserve">
+    <value>خطوة التراجع رقم {0}</value>
+  </data>
+  <data name="Optimization.Revert.Success" xml:space="preserve">
+    <value>تم التراجع عن {0} بنجاح!</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Message" xml:space="preserve">
+    <value>حدث خطأ: {0}</value>
+  </data>
+  <data name="Optimization.Toggle.Snackbar.Error.Title" xml:space="preserve">
+    <value>تعذّر تبديل حالة التحسين</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Class" xml:space="preserve">
+    <value>اسم الفئة (Class)</value>
+  </data>
+  <data name="OptimizationDetailsDialog.DetailedDescription" xml:space="preserve">
+    <value>الوصف التفصيلي</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Id" xml:space="preserve">
+    <value>معرّف التحسين</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other" xml:space="preserve">
+    <value>أخرى</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Description" xml:space="preserve">
+    <value>افتح ملف json الخام الذي يحتوي على بيانات التراجع لهذا التحسين.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.OpenRevertFile.Title" xml:space="preserve">
+    <value>ملف التراجع</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Description" xml:space="preserve">
+    <value>افتح الكود المصدري لهذا التحسين في المتصفح.</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Other.ViewSource.Title" xml:space="preserve">
+    <value>عرض الكود المصدري على GitHub</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Risk" xml:space="preserve">
+    <value>مستوى الخطورة</value>
+  </data>
+  <data name="OptimizationDetailsDialog.Tags" xml:space="preserve">
+    <value>الوسوم</value>
+  </data>
+  <data name="OptimizationDetailsDialog.TechnicalDetails" xml:space="preserve">
+    <value>التفاصيل التقنية</value>
+  </data>
+  <data name="OptimizationResultDialog.Description" xml:space="preserve">
+    <value>لم تكتمل بعض الخطوات بنجاح. يمكنك إعادة محاولة الخطوات الفاشلة فقط.</value>
+  </data>
+  <data name="OptimizationResultDialog.Details" xml:space="preserve">
+    <value>التفاصيل</value>
+  </data>
+  <data name="OptimizationResultDialog.Header" xml:space="preserve">
+    <value>{0} خطوة فاشلة</value>
+  </data>
+  <data name="Optimizations.Loading" xml:space="preserve">
+    <value>جارٍ تحميل التحسينات...</value>
+  </data>
+  <data name="Optimizations.Loading.Hint" xml:space="preserve">
+    <value>يُرجى الانتظار...</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices" xml:space="preserve">
+    <value>التطبيقات والخدمات</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Name" xml:space="preserve">
+    <value>تحسين خدمات النظام</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.Progress.ChangeServiceStartupType" xml:space="preserve">
+    <value>جارٍ ضبط نوع بدء التشغيل لـ {0} إلى {1}...</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.ConfigureServices.ShortDescription" xml:space="preserve">
+    <value>يضبط الخدمات غير الأساسية العاملة في الخلفية لتحرير الموارد مع الحفاظ على جميع وظائف ويندوز الضرورية.</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.Name" xml:space="preserve">
+    <value>منع التطبيقات المرفقة مسبقًا</value>
+  </data>
+  <data name="Optimizer.BloatwareAndServices.DisablePreinstalledApps.ShortDescription" xml:space="preserve">
+    <value>يمنع ويندوز من إعادة تثبيت تطبيقات الطرف الثالث غير المرغوبة والبرامج المروَّجة تلقائيًا.</value>
+  </data>
+  <data name="Optimizer.Gpu" xml:space="preserve">
+    <value>معالج الرسومات</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.Name" xml:space="preserve">
+    <value>تعطيل ‎ASPM‎ لكروت ‎AMD‎</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableAspm.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎EnableAspmL0s=0, EnableAspmL1=0‎ لتعطيل إدارة طاقة الحالة النشطة (ASPM) على كروت ‎AMD‎، ما يقلل زمن استجابة ناقل ‎PCIe‎. يزيد استهلاك الطاقة في المنفذ.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.Name" xml:space="preserve">
+    <value>تعطيل ‎Power Gating‎ لكروت ‎AMD‎</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisablePowerGating.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎DisablePowerGating=1, PP_GPUPowerDownEnabled=0, DisableDynamicPstate=1‎ لمنع انتقالات حالة الطاقة في كروت ‎AMD‎. يحافظ على ترددات ثابتة مقابل استهلاك أعلى في الخمول.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.Name" xml:space="preserve">
+    <value>تعطيل ‎ULPS‎ لكروت ‎AMD‎</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableUlps.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎EnableULPS=0‎ في ريجستري كرت ‎AMD‎ لمنع تأخير الاستيقاظ من حالة الطاقة فائقة الانخفاض (ULPS) ومشاكل الشاشات المتعددة. يقلل توفير الطاقة أثناء الخمول.</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.Name" xml:space="preserve">
+    <value>تعطيل ‎Video Clock Gating‎ لكروت ‎AMD‎</value>
+  </data>
+  <data name="Optimizer.Gpu.AmdDisableVideoClockGating.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎DisableVCEPowerGating=1, DisableVceClockGating=1, EnableUvdClockGating=0‎ لمحركات الفيديو في ‎AMD‎ (‎VCE/UVD‎) لتحسين استقرار الترميز وفك الترميز. يزيد استهلاك الطاقة أثناء تشغيل الفيديو.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.Name" xml:space="preserve">
+    <value>تعطيل ‎Adaptive V-Sync‎ لكروت ‎Intel‎</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAdaptiveVsync.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎AdaptiveVsyncEnable=0‎ لتعطيل التزامن الرأسي التكيّفي في ‎Intel‎ الذي يتغيّر حسب معدل الإطارات، ويستخدم تزامنًا ثابتًا بدلًا منه لتوقيت مستقر.</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.Name" xml:space="preserve">
+    <value>تعطيل ‎Async Flips‎ لكروت ‎Intel‎</value>
+  </data>
+  <data name="Optimizer.Gpu.IntelDisableAsyncFlips.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎Display1_DisableAsyncFlips=1‎ لفرض تبديل المخازن المتزامن على كرت ‎Intel‎ المدمج، ما يقلل زمن الاستجابة وتمزّق الصورة.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.Name" xml:space="preserve">
+    <value>تعطيل ‎Async P-States‎ لكروت ‎NVIDIA‎</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableAsyncPstates.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎DisableASyncPstates=1‎ لمنع التبديل غير المتزامن لحالات الطاقة في ‎NVIDIA‎، ما يوفر أداءً ثابتًا لتطبيقات الواقع الافتراضي والزمن الحقيقي.</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.Name" xml:space="preserve">
+    <value>تعطيل ‎Dynamic P-State‎ لكروت ‎NVIDIA‎</value>
+  </data>
+  <data name="Optimizer.Gpu.NvidiaDisableDynamicPstate.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎DisableDynamicPstate=1‎ لتثبيت كرت ‎NVIDIA‎ على حالة أداء ثابتة ومنع تذبذب الترددات. يزيد استهلاك الطاقة في الخمول.</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAll" xml:space="preserve">
+    <value>تطبيق الكل</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyAllSafe" xml:space="preserve">
+    <value>تطبيق الآمن فقط</value>
+  </data>
+  <data name="Optimizer.Menu.ApplyMenu" xml:space="preserve">
+    <value>تطبيق</value>
+  </data>
+  <data name="Optimizer.Menu.BatchApply.Title" xml:space="preserve">
+    <value>جارٍ تطبيق التحسينات</value>
+  </data>
+  <data name="Optimizer.Menu.HideApplied" xml:space="preserve">
+    <value>إخفاء المُطبَّق</value>
+  </data>
+  <data name="Optimizer.Menu.ViewSource" xml:space="preserve">
+    <value>عرض الكود المصدري</value>
+  </data>
+  <data name="Optimizer.Performance" xml:space="preserve">
+    <value>الأداء</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.Name" xml:space="preserve">
+    <value>تعطيل اختصارات سهولة الوصول</value>
+  </data>
+  <data name="Optimizer.Performance.DisableAccessibilityKeyboardHotkeys.ShortDescription" xml:space="preserve">
+    <value>يعطّل اختصارات المفاتيح الثابتة (Sticky Keys) ومفاتيح التصفية (Filter Keys) ومفاتيح التبديل (Toggle Keys) لمنع ظهور النوافذ المنبثقة أثناء اللعب والكتابة.</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.Name" xml:space="preserve">
+    <value>تعطيل تطبيقات الخلفية</value>
+  </data>
+  <data name="Optimizer.Performance.DisableBackgroundApps.ShortDescription" xml:space="preserve">
+    <value>يمنع التطبيقات غير النشطة من العمل في الخلفية لتحرير الذاكرة (RAM) وتقليل الحمل على المعالج.</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
+    <value>تحسين تكرار لوحة المفاتيح</value>
+  </data>
+  <data name="Optimizer.Performance.KeyboardLatencyOptimization.ShortDescription" xml:space="preserve">
+    <value>يضبط أسرع قيم لتأخير التكرار ومعدّله للحصول على استجابة أسرع عند الكتابة وتكرار الضغط.</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.Name" xml:space="preserve">
+    <value>تحسين مجدول الوسائط المتعددة</value>
+  </data>
+  <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
+    <value>يضبط خدمة جدولة فئة الوسائط المتعددة (MMCSS) للألعاب وزمن الاستجابة المنخفض عبر إعطاء الأولوية لأحمال الوسائط وتعطيل خنق الشبكة.</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.Name" xml:space="preserve">
+    <value>إعطاء الأولوية للتطبيقات النشطة</value>
+  </data>
+  <data name="Optimizer.Performance.ProcessPriority.ShortDescription" xml:space="preserve">
+    <value>يخصص موارد معالج أكثر للتطبيق الذي تستخدمه حاليًا لتجربة أسرع وأكثر استجابة.</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Error.InvalidRAM" xml:space="preserve">
+    <value>قيمة ذاكرة غير صالحة: {0}</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.Name" xml:space="preserve">
+    <value>تحسين عزل الخدمات</value>
+  </data>
+  <data name="Optimizer.Performance.SvcHostSplit.ShortDescription" xml:space="preserve">
+    <value>يضبط عتبة تقسيم ‎Service Host‎ لتطابق إجمالي ذاكرة النظام، ما يجبر ويندوز على عزل الخدمات في عمليات منفصلة لتحسين الاستقرار.</value>
+  </data>
+  <data name="Optimizer.PowerManagement" xml:space="preserve">
+    <value>إدارة الطاقة</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.Name" xml:space="preserve">
+    <value>تعطيل الإسبات وبدء التشغيل السريع</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableHibernateAndFastStartup.ShortDescription" xml:space="preserve">
+    <value>يوقف الإسبات وبدء التشغيل السريع لاستعادة مساحة القرص وضمان إيقاف تشغيل كامل لتهيئة أنظف للعتاد عند الإقلاع.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.Name" xml:space="preserve">
+    <value>تعطيل خنق طاقة النظام</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisablePowerSaving.ShortDescription" xml:space="preserve">
+    <value>يمنع ويندوز من تقييد أداء المعالج (Power Throttling) للحفاظ على أقصى طاقة للمهام النشطة.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.Name" xml:space="preserve">
+    <value>تعطيل توفير طاقة ‎USB‎</value>
+  </data>
+  <data name="Optimizer.PowerManagement.DisableUSBPowerSaving.ShortDescription" xml:space="preserve">
+    <value>يمنع ويندوز من إيقاف طاقة منافذ ‎USB‎، ما يلغي تأخير الاستيقاظ للفأرة ولوحة المفاتيح والملحقات الأخرى.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ActivateFailed" xml:space="preserve">
+    <value>فشل تفعيل خطة الطاقة الخاصة بـ‎optimizerDuck‎.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DetectActivePlanFailed" xml:space="preserve">
+    <value>فشل تحديد خطة الطاقة النشطة حاليًا.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.DownloadFailed" xml:space="preserve">
+    <value>فشل تنزيل خطة الطاقة الخاصة بـ‎optimizerDuck‎.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Error.ImportFailed" xml:space="preserve">
+    <value>فشل استيراد خطة الطاقة الخاصة بـ‎optimizerDuck‎.</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Name" xml:space="preserve">
+    <value>تطبيق خطة طاقة محسّنة</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.Progress.Importing" xml:space="preserve">
+    <value>جارٍ استيراد خطة الطاقة وتفعيلها...</value>
+  </data>
+  <data name="Optimizer.PowerManagement.InstallOptimizerDuckPowerPlan.ShortDescription" xml:space="preserve">
+    <value>يثبّت خطة طاقة مخصصة تركّز على الأداء لضمان عمل نظامك بأقصى سرعة دائمًا. تحذير: قد تُظهر إدارة المهام استهلاك المعالج بنسبة 100% بشكل غير صحيح على بعض الأجهزة، والحمل الفعلي غير متأثر.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy" xml:space="preserve">
+    <value>الأمان والخصوصية</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.Name" xml:space="preserve">
+    <value>تعطيل سجل الأنشطة</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableActivityHistory.ShortDescription" xml:space="preserve">
+    <value>يمنع ويندوز من جمع سجل أنشطتك ومزامنته.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.Name" xml:space="preserve">
+    <value>تعطيل الإعلانات والاقتراحات</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAdvertisingAndSuggestions.ShortDescription" xml:space="preserve">
+    <value>يعطّل الإعلانات المخصصة وميزات ويندوز الاستهلاكية واقتراحات النظام.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.Name" xml:space="preserve">
+    <value>تعطيل التسجيل في الخلفية</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableAutoLogger.ShortDescription" xml:space="preserve">
+    <value>يوقف تسجيل أحداث النظام غير الضرورية لتقليل نشاط القرص المستمر وتوفير دورات المعالج.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.Name" xml:space="preserve">
+    <value>تعطيل المحتوى السحابي</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableContentDeliveryManager.ShortDescription" xml:space="preserve">
+    <value>يوقف المحتوى الذي يوصله ويندوز عبر السحابة، بما في ذلك تلميحات النظام واقتراحات ‎Spotlight‎ والتوصيل التلقائي للميزات الاستهلاكية.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.Name" xml:space="preserve">
+    <value>تعطيل ‎Windows Copilot‎</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCopilot.ShortDescription" xml:space="preserve">
+    <value>يزيل مساعد ‎Copilot‎ الذكي من شريط المهام وواجهة النظام لتوفير الذاكرة ومساحة الشاشة.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.Name" xml:space="preserve">
+    <value>تعطيل ‎Cortana‎ والبحث على الويب</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableCortana.ShortDescription" xml:space="preserve">
+    <value>يوقف المساعد الصوتي ‎Cortana‎ ويزيل نتائج ‎Bing‎ من شريط بحث ويندوز.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.Name" xml:space="preserve">
+    <value>تعطيل تقارير الأخطاء</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableErrorReporting.ShortDescription" xml:space="preserve">
+    <value>يعطّل خدمتَي تقارير أخطاء ويندوز ومساعد توافق البرامج.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.Name" xml:space="preserve">
+    <value>تعطيل الموقع والمستشعرات</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableLocationAndSensors.ShortDescription" xml:space="preserve">
+    <value>يعطّل تتبّع الموقع ومستشعرات النظام وتحديثات الخرائط دون اتصال.</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Name" xml:space="preserve">
+    <value>تعطيل جمع البيانات (Telemetry)</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableServices" xml:space="preserve">
+    <value>جارٍ تعطيل خدمات القياس عن بُعد...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.DisableTasks" xml:space="preserve">
+    <value>جارٍ تعطيل مهام القياس عن بُعد المجدولة...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.Progress.EditRegistry" xml:space="preserve">
+    <value>جارٍ تطبيق تغييرات السياسة والريجستري...</value>
+  </data>
+  <data name="Optimizer.SecurityAndPrivacy.DisableTelemetry.ShortDescription" xml:space="preserve">
+    <value>يعطّل خدمات القياس عن بُعد (Telemetry) وتتبّع الاستخدام في ويندوز لتعزيز خصوصيتك وتقليل النشاط في الخلفية.</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Help" xml:space="preserve">
+    <value>تعكس هذه القيمة مدى تدخّل التحسين في النظام ودرجة أمانه. توخَّ الحذر وفكّر جيدًا قبل تطبيق أي تحسين.</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Moderate" xml:space="preserve">
+    <value>بحذر</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Risky" xml:space="preserve">
+    <value>للخبراء</value>
+  </data>
+  <data name="Optimizer.UI.Risk.Safe" xml:space="preserve">
+    <value>آمن</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Amd" xml:space="preserve">
+    <value>AMD</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Audio" xml:space="preserve">
+    <value>الصوت</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Disk" xml:space="preserve">
+    <value>القرص</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Display" xml:space="preserve">
+    <value>العرض</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Help" xml:space="preserve">
+    <value>تشير هذه الوسوم إلى أجزاء النظام التي سيؤثر عليها التحسين.</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Intel" xml:space="preserve">
+    <value>Intel</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Latency" xml:space="preserve">
+    <value>زمن الاستجابة</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Network" xml:space="preserve">
+    <value>الشبكة</value>
+  </data>
+  <data name="Optimizer.UI.Tags.NetworkRequired" xml:space="preserve">
+    <value>يتطلب اتصالًا بالإنترنت</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Nvidia" xml:space="preserve">
+    <value>NVIDIA</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Performance" xml:space="preserve">
+    <value>الأداء</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Power" xml:space="preserve">
+    <value>الطاقة</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Privacy" xml:space="preserve">
+    <value>الخصوصية</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Ram" xml:space="preserve">
+    <value>الذاكرة (RAM)</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Security" xml:space="preserve">
+    <value>الأمان</value>
+  </data>
+  <data name="Optimizer.UI.Tags.System" xml:space="preserve">
+    <value>النظام</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Visual" xml:space="preserve">
+    <value>المؤثرات البصرية</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Windows10Only" xml:space="preserve">
+    <value>ويندوز 10 فقط</value>
+  </data>
+  <data name="Optimizer.UI.Tags.Windows11Only" xml:space="preserve">
+    <value>ويندوز 11 فقط</value>
+  </data>
+  <data name="Optimizer.UserExperience" xml:space="preserve">
+    <value>تجربة المستخدم</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.Name" xml:space="preserve">
+    <value>تعطيل بحث الويب في قائمة ابدأ</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.ShortDescription" xml:space="preserve">
+    <value>يوقف البحث على الويب في قائمة ابدأ لتحميل نتائج البحث المحلية بشكل أسرع.</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.Name" xml:space="preserve">
+    <value>تعطيل المؤثرات البصرية</value>
+  </data>
+  <data name="Optimizer.UserExperience.DisableVisualEffects.ShortDescription" xml:space="preserve">
+    <value>يعطّل حركات شريط المهام وظلال القوائم وشفافية النوافذ وميزة ‎Aero Peek‎ لتحرير موارد المعالج وكرت الرسومات وتحسين الأداء.</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.Name" xml:space="preserve">
+    <value>تسريع مستكشف الملفات والقوائم</value>
+  </data>
+  <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
+    <value>يضبط ‎StartupDelayInMSec=0, MenuShowDelay=0‎ لإلغاء تأخير بدء مستكشف الملفات وتقليل تأخير ظهور القوائم إلى الحد الأدنى.</value>
+  </data>
+  <data name="ProcessingOptimizationDialog.Warning.DontCloseAppOrRestart" xml:space="preserve">
+    <value>يُرجى عدم إغلاق التطبيق أو إعادة تشغيل الجهاز أثناء تطبيق التغييرات أو التراجع عنها.</value>
+  </data>
+  <data name="RestorePoint.Progress.Creating" xml:space="preserve">
+    <value>جارٍ إنشاء نقطة استعادة...</value>
+  </data>
+  <data name="RestorePoint.Progress.Enabling" xml:space="preserve">
+    <value>جارٍ تفعيل استعادة النظام...</value>
+  </data>
+  <data name="RestorePoint.Progress.Retrying" xml:space="preserve">
+    <value>جارٍ إعادة محاولة إنشاء نقطة الاستعادة...</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Message" xml:space="preserve">
+    <value>حدث خطأ أثناء إنشاء استعادة النظام أو تفعيلها. يُرجى محاولة إنشائها يدويًا.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Error.Title" xml:space="preserve">
+    <value>تعذّر إنشاء استعادة النظام أو تفعيلها.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Message" xml:space="preserve">
+    <value>أُنشئت نقطة استعادة بالاسم: {0}‎.</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Success.Title" xml:space="preserve">
+    <value>أُنشئت نقطة الاستعادة بنجاح</value>
+  </data>
+  <data name="RestorePoint.Snackbar.Warning.LimitReached" xml:space="preserve">
+    <value>أُنشئت نقطة استعادة بالفعل خلال الـ 24 ساعة الماضية.</value>
+  </data>
+  <data name="RestorePoint.Title" xml:space="preserve">
+    <value>استعادة النظام</value>
+  </data>
+  <data name="RestorePointDialog.Description" xml:space="preserve">
+    <value>تتيح لك نقطة الاستعادة إرجاع نظامك إلى حالة سابقة.
+وهي إجراء وقائي لحماية ويندوز قبل تطبيق التغييرات.</value>
+  </data>
+  <data name="RestorePointDialog.Help" xml:space="preserve">
+    <value>سيفعّل التطبيق استعادة النظام تلقائيًا وينشئ نقطة تحقق باسم «‎optimizerDuck...‎».
+هذا يضمن إمكانية الرجوع دائمًا إذا حدث خطأ ما.</value>
+  </data>
+  <data name="Revert.Error.FileEmpty" xml:space="preserve">
+    <value>ملف التراجع فارغ</value>
+  </data>
+  <data name="Revert.Error.FileNotFound" xml:space="preserve">
+    <value>ملف التراجع غير موجود</value>
+  </data>
+  <data name="Revert.Error.InvalidData" xml:space="preserve">
+    <value>بيانات تراجع غير صالحة لـ {0}: {1}</value>
+  </data>
+  <data name="Revert.Error.InvalidJson" xml:space="preserve">
+    <value>بيانات تراجع غير صالحة</value>
+  </data>
+  <data name="Revert.Error.InvalidJsonFormat" xml:space="preserve">
+    <value>صيغة ‎JSON‎ غير صالحة: {0}</value>
+  </data>
+  <data name="Revert.Error.InvalidSteps" xml:space="preserve">
+    <value>خطوات تراجع غير صالحة: {0}</value>
+  </data>
+  <data name="Revert.Error.NoDataFound" xml:space="preserve">
+    <value>لا توجد بيانات تراجع لـ {0}‎.</value>
+  </data>
+  <data name="Revert.Error.NoSteps" xml:space="preserve">
+    <value>لم يتم العثور على خطوات تراجع.</value>
+  </data>
+  <data name="Revert.Error.OptimizationIdMismatch" xml:space="preserve">
+    <value>عدم تطابق معرّف التحسين.</value>
+  </data>
+  <data name="Revert.Error.ReadFailed" xml:space="preserve">
+    <value>فشل قراءة بيانات التراجع: {0}</value>
+  </data>
+  <data name="Revert.Error.RevertFailed" xml:space="preserve">
+    <value>فشل التراجع عن {0}: {1}</value>
+  </data>
+  <data name="Revert.Error.StepFailed" xml:space="preserve">
+    <value>فشلت خطوة التراجع</value>
+  </data>
+  <data name="Revert.Registry.Description.Delete" xml:space="preserve">
+    <value>حذف قيمة الريجستري: ‎{0}\{1}‎</value>
+  </data>
+  <data name="Revert.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>حذف مفتاح الريجستري: ‎{0}‎</value>
+  </data>
+  <data name="Revert.Registry.Description.Restore" xml:space="preserve">
+    <value>استعادة قيمة الريجستري: ‎{0}\{1}‎</value>
+  </data>
+  <data name="Revert.Registry.Description.RestoreKey" xml:space="preserve">
+    <value>استعادة مفتاح الريجستري: ‎{0}‎</value>
+  </data>
+  <data name="Revert.Registry.Description.RevertUnknown" xml:space="preserve">
+    <value>التراجع عن الريجستري: ‎{0}‎</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>تعطيل المهمة المجدولة: ‎{0}‎</value>
+  </data>
+  <data name="Revert.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>تفعيل المهمة المجدولة: ‎{0}‎</value>
+  </data>
+  <data name="Revert.Service.Description.Restore" xml:space="preserve">
+    <value>استعادة بدء تشغيل الخدمة «{0}» إلى {1}</value>
+  </data>
+  <data name="Revert.Shell.Description.Run" xml:space="preserve">
+    <value>تنفيذ أمر {0}: {1}</value>
+  </data>
+  <data name="Revert.Shell.Error.CommandFailed" xml:space="preserve">
+    <value>فشل أمر التراجع برمز خروج {0}</value>
+  </data>
+  <data name="Revert.Shell.Error.UnknownShellType" xml:space="preserve">
+    <value>نوع طرفية غير معروف</value>
+  </data>
+  <data name="Revert.UsbPower.Description" xml:space="preserve">
+    <value>استعادة حالات طاقة التعليق الانتقائي لمنافذ ‎USB‎</value>
+  </data>
+  <data name="Revert.UsbPower.Error.CommandFailed" xml:space="preserve">
+    <value>فشل التراجع عن طاقة ‎USB‎ برمز خروج {0}</value>
+  </data>
+  <data name="ScheduledTasks.Action.Delete" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+  <data name="ScheduledTasks.Action.Details" xml:space="preserve">
+    <value>عرض التفاصيل</value>
+  </data>
+  <data name="ScheduledTasks.Action.Run" xml:space="preserve">
+    <value>تشغيل</value>
+  </data>
+  <data name="ScheduledTasks.Action.Stop" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="ScheduledTasks.Details.Action" xml:space="preserve">
+    <value>الإجراء</value>
+  </data>
+  <data name="ScheduledTasks.Details.Author" xml:space="preserve">
+    <value>المُنشِئ</value>
+  </data>
+  <data name="ScheduledTasks.Details.Description" xml:space="preserve">
+    <value>الوصف</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastResult" xml:space="preserve">
+    <value>نتيجة آخر تشغيل</value>
+  </data>
+  <data name="ScheduledTasks.Details.LastRun" xml:space="preserve">
+    <value>آخر تشغيل</value>
+  </data>
+  <data name="ScheduledTasks.Details.Name" xml:space="preserve">
+    <value>الاسم</value>
+  </data>
+  <data name="ScheduledTasks.Details.NextRun" xml:space="preserve">
+    <value>التشغيل التالي</value>
+  </data>
+  <data name="ScheduledTasks.Details.Path" xml:space="preserve">
+    <value>المسار</value>
+  </data>
+  <data name="ScheduledTasks.Details.State" xml:space="preserve">
+    <value>الحالة</value>
+  </data>
+  <data name="ScheduledTasks.Details.Triggers" xml:space="preserve">
+    <value>المشغّلات</value>
+  </data>
+  <data name="ScheduledTasks.Dialog.DeleteMessage" xml:space="preserve">
+    <value>هل أنت متأكد من حذف المهمة «{0}»؟ لا يمكن التراجع عن هذا الإجراء.</value>
+  </data>
+  <data name="ScheduledTasks.Dialog.DeleteTitle" xml:space="preserve">
+    <value>حذف مهمة مجدولة</value>
+  </data>
+  <data name="ScheduledTasks.Dialog.DeleteWarning" xml:space="preserve">
+    <value>حذف المهمة المجدولة نهائي. لن تعمل المهمة تلقائيًا بعد الآن.</value>
+  </data>
+  <data name="ScheduledTasks.Error.TaskNotFound" xml:space="preserve">
+    <value>لم يتم العثور على المهمة: {0}</value>
+  </data>
+  <data name="ScheduledTasks.Header.Description" xml:space="preserve">
+    <value>اعرض مهام ويندوز المجدولة وأدِرها.</value>
+  </data>
+  <data name="ScheduledTasks.Header.Title" xml:space="preserve">
+    <value>المهام المجدولة</value>
+  </data>
+  <data name="ScheduledTasks.HideMicrosoft" xml:space="preserve">
+    <value>إخفاء مهام ‎Microsoft‎</value>
+  </data>
+  <data name="ScheduledTasks.Loading" xml:space="preserve">
+    <value>جارٍ تحميل المهام المجدولة...</value>
+  </data>
+  <data name="ScheduledTasks.Loading.Hint" xml:space="preserve">
+    <value>قد يستغرق هذا لحظة أثناء فحص جميع المهام المجدولة على نظامك...</value>
+  </data>
+  <data name="ScheduledTasks.Menu.CreateTask" xml:space="preserve">
+    <value>إنشاء مهمة</value>
+  </data>
+  <data name="ScheduledTasks.Menu.OpenSettings" xml:space="preserve">
+    <value>فتح برنامج جدولة المهام</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Message" xml:space="preserve">
+    <value>تم إنشاء {0} بنجاح.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Create.Title" xml:space="preserve">
+    <value>أُنشئت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Message" xml:space="preserve">
+    <value>تم حذف {0}‎.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Delete.Title" xml:space="preserve">
+    <value>حُذفت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Disabled.Title" xml:space="preserve">
+    <value>عُطّلت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Enabled.Title" xml:space="preserve">
+    <value>فُعّلت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Error.Title" xml:space="preserve">
+    <value>خطأ</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Message" xml:space="preserve">
+    <value>{0} قيد التشغيل الآن.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Run.Title" xml:space="preserve">
+    <value>بدأت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Message" xml:space="preserve">
+    <value>تم إيقاف {0}‎.</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Stop.Title" xml:space="preserve">
+    <value>أُوقفت المهمة</value>
+  </data>
+  <data name="ScheduledTasks.Snackbar.Toggle.Message" xml:space="preserve">
+    <value>تم تحديث {0} بنجاح.</value>
+  </data>
+  <data name="Service.Common.Error.AccessDenied" xml:space="preserve">
+    <value>تم رفض الوصول</value>
+  </data>
+  <data name="Service.Registry.Description.CreateKey" xml:space="preserve">
+    <value>إنشاء مفتاح الريجستري ‎{0}‎</value>
+  </data>
+  <data name="Service.Registry.Description.Delete" xml:space="preserve">
+    <value>حذف قيمة الريجستري: ‎{0}\{1}‎</value>
+  </data>
+  <data name="Service.Registry.Description.DeleteKey" xml:space="preserve">
+    <value>حذف مفتاح الريجستري ‎{0}‎</value>
+  </data>
+  <data name="Service.Registry.Description.Write" xml:space="preserve">
+    <value>كتابة قيمة الريجستري: ‎{0}\{1}‎</value>
+  </data>
+  <data name="Service.Registry.Error.AccessDeniedProtectedHive" xml:space="preserve">
+    <value>تم رفض الوصول (خلية محمية)</value>
+  </data>
+  <data name="Service.Registry.Error.BackupTruncated" xml:space="preserve">
+    <value>شجرة الريجستري الفرعية أكبر من أن تُنسخ احتياطيًا بأمان؛ أُلغي الحذف لـ ‎{0}‎</value>
+  </data>
+  <data name="Service.Registry.Error.CreateOrOpenSubkeyFailed" xml:space="preserve">
+    <value>فشل إنشاء المفتاح الفرعي أو فتحه</value>
+  </data>
+  <data name="Service.Registry.Error.UnauthorizedAccess" xml:space="preserve">
+    <value>وصول غير مصرّح به</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedCreateKey" xml:space="preserve">
+    <value>تم رفض الوصول عند إنشاء ‎{0}‎</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDelete" xml:space="preserve">
+    <value>تم رفض الوصول عند حذف ‎{0}:{1}‎</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedDeleteKeyTree" xml:space="preserve">
+    <value>تم رفض الوصول عند حذف شجرة المفتاح ‎{0}‎</value>
+  </data>
+  <data name="Service.Registry.ErrorDetail.AccessDeniedWrite" xml:space="preserve">
+    <value>تم رفض الوصول عند كتابة ‎{0}:{1}‎</value>
+  </data>
+  <data name="Service.Registry.Name" xml:space="preserve">
+    <value>الريجستري</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Disable" xml:space="preserve">
+    <value>تعطيل المهمة المجدولة: ‎{0}‎</value>
+  </data>
+  <data name="Service.ScheduledTask.Description.Enable" xml:space="preserve">
+    <value>تفعيل المهمة المجدولة: ‎{0}‎</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedDisable" xml:space="preserve">
+    <value>تم رفض الوصول عند تعطيل المهمة ‎{0}‎</value>
+  </data>
+  <data name="Service.ScheduledTask.ErrorDetail.AccessDeniedEnable" xml:space="preserve">
+    <value>تم رفض الوصول عند تفعيل المهمة ‎{0}‎</value>
+  </data>
+  <data name="Service.ScheduledTask.Name" xml:space="preserve">
+    <value>مهمة مجدولة</value>
+  </data>
+  <data name="Service.Service.Description.Change" xml:space="preserve">
+    <value>تغيير بدء تشغيل الخدمة «{0}» إلى {1}</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartModeFailedWithCode" xml:space="preserve">
+    <value>فشل ‎ChangeStartMode‎ (الرمز: {0})</value>
+  </data>
+  <data name="Service.Service.Error.ChangeStartupTypeFailed" xml:space="preserve">
+    <value>فشل تغيير نوع بدء تشغيل الخدمة</value>
+  </data>
+  <data name="Service.Service.Error.ExceptionOccurred" xml:space="preserve">
+    <value>فشل تغيير الخدمة «{0}»: {1}</value>
+  </data>
+  <data name="Service.Service.Error.NotFound" xml:space="preserve">
+    <value>الخدمة غير موجودة</value>
+  </data>
+  <data name="Service.Service.Info.SkippedNotFound" xml:space="preserve">
+    <value>الخدمة «{0}» غير موجودة (تم تخطّيها)</value>
+  </data>
+  <data name="Service.Service.Name" xml:space="preserve">
+    <value>خدمة</value>
+  </data>
+  <data name="Service.Shell.Error.ExitCode" xml:space="preserve">
+    <value>رمز الخروج {0}</value>
+  </data>
+  <data name="Service.Shell.Error.TimedOut" xml:space="preserve">
+    <value>انتهت المهلة</value>
+  </data>
+  <data name="Service.Shell.Name" xml:space="preserve">
+    <value>الأوامر</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Description" xml:space="preserve">
+    <value>تحقّق optimizerDuck بفضل البرمجيات والموارد مفتوحة المصدر التالية.</value>
+  </data>
+  <data name="Settings.About.Acknowledgements.Title" xml:space="preserve">
+    <value>شكر وتقدير</value>
+  </data>
+  <data name="Settings.About.Documentation.Description" xml:space="preserve">
+    <value>اطّلع على التوثيق وأدلة الاستخدام والأسئلة الشائعة.</value>
+  </data>
+  <data name="Settings.About.Documentation.Title" xml:space="preserve">
+    <value>التوثيق</value>
+  </data>
+  <data name="Settings.About.Duck.Description" xml:space="preserve">
+    <value>الإصدار الحالي: {0}</value>
+  </data>
+  <data name="Settings.About.Header" xml:space="preserve">
+    <value>حول</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Description" xml:space="preserve">
+    <value>إذا احتجت مساعدة في التحسين أو كان لديك أي استفسار، انضم إلى مجتمعنا للحصول على دعم سريع.</value>
+  </data>
+  <data name="Settings.About.NeedHelp.Title" xml:space="preserve">
+    <value>تحتاج مساعدة؟</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Description" xml:space="preserve">
+    <value>احذف جميع الملفات التي نُزّلت أثناء عملية التحسين.</value>
+  </data>
+  <data name="Settings.Advanced.ClearDownloads.Title" xml:space="preserve">
+    <value>مسح التنزيلات</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Description" xml:space="preserve">
+    <value>امسح جميع بيانات التراجع الناتجة عن التحسينات.</value>
+  </data>
+  <data name="Settings.Advanced.ClearRevertDatas.Title" xml:space="preserve">
+    <value>مسح جميع بيانات التراجع</value>
+  </data>
+  <data name="Settings.Advanced.Header" xml:space="preserve">
+    <value>متقدّم</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Description" xml:space="preserve">
+    <value>افتح المجلد الجذر للتطبيق، حيث تُخزَّن جميع الملفات اللازمة.</value>
+  </data>
+  <data name="Settings.Advanced.OpenRootDir.Title" xml:space="preserve">
+    <value>فتح المجلد الجذر</value>
+  </data>
+  <data name="Settings.Appearance.Header" xml:space="preserve">
+    <value>المظهر</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Description" xml:space="preserve">
+    <value>اختر لغتك المفضلة.</value>
+  </data>
+  <data name="Settings.Appearance.LanguageSelector.Title" xml:space="preserve">
+    <value>اللغة</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Description" xml:space="preserve">
+    <value>تفعيل حركة تمرير سلسة لتجربة أكثر انسيابية. أوقفه إذا واجهت بطئًا.</value>
+  </data>
+  <data name="Settings.Appearance.SmoothScrolling.Title" xml:space="preserve">
+    <value>التمرير السلس</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Dark" xml:space="preserve">
+    <value>داكن</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Description" xml:space="preserve">
+    <value>اختر السمة المفضلة للتطبيق.</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.HighContrast" xml:space="preserve">
+    <value>تباين عالٍ</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Light" xml:space="preserve">
+    <value>فاتح</value>
+  </data>
+  <data name="Settings.Appearance.ThemeSelector.Title" xml:space="preserve">
+    <value>السمة</value>
+  </data>
+  <data name="Settings.Bloatware.Header" xml:space="preserve">
+    <value>التطبيقات المرفقة (Bloatware)</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Description" xml:space="preserve">
+    <value>عند إزالة حزم التطبيقات المثبّتة (AppX)، تُزال أيضًا الحزم المُهيّأة (Provisioned) المقابلة لمنع إعادة تثبيتها تلقائيًا للمستخدمين الجدد.</value>
+  </data>
+  <data name="Settings.Bloatware.RemoveProvisioned.Title" xml:space="preserve">
+    <value>إزالة الحزم المُهيّأة (Provisioned)</value>
+  </data>
+  <data name="Settings.ClearDownloads.Description" xml:space="preserve">
+    <value>أنت على وشك حذف جميع الملفات التي نُزّلت أثناء عملية التحسين. لاحظ أن هذا الإجراء نهائي ولا يمكن التراجع عنه، فتأكّد قبل المتابعة.</value>
+  </data>
+  <data name="Settings.ClearRevertData.Description" xml:space="preserve">
+    <value>أنت على وشك حذف جميع بيانات التراجع الناتجة بعد عملية التحسين. هذا يعني أنك لن تتمكن من استعادة الحالة السابقة للتحسين، ففكّر جيدًا قبل التأكيد.</value>
+  </data>
+  <data name="Settings.Header.Title" xml:space="preserve">
+    <value>الإعدادات</value>
+  </data>
+  <data name="Settings.LanguageChanged.Description" xml:space="preserve">
+    <value>يجب إعادة تشغيل التطبيق لتطبيق اللغة الجديدة.</value>
+  </data>
+  <data name="Settings.LanguageChanged.Title" xml:space="preserve">
+    <value>تغيير اللغة</value>
+  </data>
+  <data name="Settings.Optimize.Header" xml:space="preserve">
+    <value>التحسين</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Description" xml:space="preserve">
+    <value>المهلة الزمنية لتنفيذ كل أمر طرفية (Shell) بالمللي ثانية.</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Title" xml:space="preserve">
+    <value>مهلة خدمة الأوامر (Shell)</value>
+  </data>
+  <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
+    <value>لا تُغيّر هذه القيمة إلا إذا كنت تعرف تمامًا ما تفعله</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Description" xml:space="preserve">
+    <value>يعرض إشعارًا عند تطبيق التحسينات أو التراجع عنها بنجاح.</value>
+  </data>
+  <data name="Settings.Optimize.ShowCompletionNotification.Title" xml:space="preserve">
+    <value>إظهار إشعار الاكتمال</value>
+  </data>
+  <data name="Sidebar.Bloatware" xml:space="preserve">
+    <value>التطبيقات المرفقة</value>
+  </data>
+  <data name="Sidebar.Customize" xml:space="preserve">
+    <value>التخصيص</value>
+  </data>
+  <data name="Sidebar.Dashboard" xml:space="preserve">
+    <value>لوحة المعلومات</value>
+  </data>
+  <data name="Sidebar.DiskCleanup" xml:space="preserve">
+    <value>تنظيف القرص</value>
+  </data>
+  <data name="Sidebar.Optimize" xml:space="preserve">
+    <value>التحسين</value>
+  </data>
+  <data name="Sidebar.ScheduledTasks" xml:space="preserve">
+    <value>المهام المجدولة</value>
+  </data>
+  <data name="Sidebar.Settings" xml:space="preserve">
+    <value>الإعدادات</value>
+  </data>
+  <data name="Sidebar.StartupManager" xml:space="preserve">
+    <value>مدير بدء التشغيل</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Message" xml:space="preserve">
+    <value>حدث خطأ أثناء فتح المجلد أو الملف. يُرجى مراجعة السجل.</value>
+  </data>
+  <data name="Snackbar.OpenFailed.Title" xml:space="preserve">
+    <value>تعذّر فتح المجلد أو الملف</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Message" xml:space="preserve">
+    <value>حدث خطأ أثناء فتح المسار. يُرجى مراجعة السجل.</value>
+  </data>
+  <data name="Snackbar.OpenLinkFailed.Title" xml:space="preserve">
+    <value>تعذّر فتح المسار</value>
+  </data>
+  <data name="StartupManager.Apps.CountSuffix" xml:space="preserve">
+    <value>{0} عنصر</value>
+  </data>
+  <data name="StartupManager.Apps.Description" xml:space="preserve">
+    <value>التطبيقات التي تعمل تلقائيًا عند بدء ويندوز.</value>
+  </data>
+  <data name="StartupManager.Apps.Title" xml:space="preserve">
+    <value>تطبيقات بدء التشغيل</value>
+  </data>
+  <data name="StartupManager.Empty.Description" xml:space="preserve">
+    <value>لم يُعثر على أي تطبيقات بدء تشغيل أو مهام مجدولة على هذا النظام.</value>
+  </data>
+  <data name="StartupManager.Empty.Title" xml:space="preserve">
+    <value>لا توجد عناصر بدء تشغيل</value>
+  </data>
+  <data name="StartupManager.Header.Description" xml:space="preserve">
+    <value>أدِر التطبيقات والمهام التي تعمل تلقائيًا عند بدء ويندوز.</value>
+  </data>
+  <data name="StartupManager.Header.Title" xml:space="preserve">
+    <value>مدير بدء التشغيل</value>
+  </data>
+  <data name="StartupManager.Loading" xml:space="preserve">
+    <value>جارٍ فحص عناصر بدء التشغيل...</value>
+  </data>
+  <data name="StartupManager.Loading.Hint" xml:space="preserve">
+    <value>قد يستغرق هذا لحظة بينما يفحص التطبيق الريجستري ومجلدات بدء التشغيل.</value>
+  </data>
+  <data name="StartupManager.Menu.OpenSettings" xml:space="preserve">
+    <value>فتح الإعدادات</value>
+  </data>
+  <data name="StartupManager.Menu.Refresh" xml:space="preserve">
+    <value>تحديث</value>
+  </data>
+  <data name="StartupManager.Tasks.CountSuffix" xml:space="preserve">
+    <value>{0} مهمة</value>
+  </data>
+  <data name="StartupManager.Tasks.Description" xml:space="preserve">
+    <value>مهام ويندوز المهيّأة للعمل عند تسجيل الدخول أو وفق جدول زمني.</value>
+  </data>
+  <data name="StartupManager.Tasks.HideMicrosoft" xml:space="preserve">
+    <value>إخفاء مهام ‎Microsoft‎</value>
+  </data>
+  <data name="StartupManager.Tasks.Title" xml:space="preserve">
+    <value>المهام المجدولة (عند تسجيل الدخول)</value>
+  </data>
+  <data name="TitleBar.Discord" xml:space="preserve">
+    <value>الانضمام إلى مجتمع Discord</value>
+  </data>
+  <data name="TitleBar.Support" xml:space="preserve">
+    <value>ادعم المشروع</value>
+  </data>
+</root>

--- a/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
+++ b/optimizerDuck/UI/ViewModels/Pages/SettingsViewModel.cs
@@ -67,6 +67,7 @@ public partial class SettingsViewModel(
         new() { DisplayName = "Português (BR)", Culture = new CultureInfo("pt-BR") },
         new() { DisplayName = "Türkçe", Culture = new CultureInfo("tr-TR") },
         new() { DisplayName = "עברית", Culture = new CultureInfo("he-IL") },
+        new() { DisplayName = "العربية", Culture = new CultureInfo("ar-SA") },
     ];
 
     protected override Task InitializeOnceAsync()


### PR DESCRIPTION
## Description

Adds a complete Arabic (ar-SA) translation for optimizerDuck — all 576
keys in `Translations.resx`, plus an Arabic README and language switcher
entries in the other README files.

**Translation decisions:**

- **Culture**: `ar-SA`
- **Technical terms**: Arabic with the English term in parentheses,
  e.g. "القياس عن بُعد (Telemetry)". Product and brand names
  (Cortana, Copilot, Xbox Game Bar, AMD, Intel, NVIDIA) are left as-is.
- **Windows features**: use Microsoft's official Arabic terminology so
  the wording matches what users already see in Arabic Windows.
- **Narrow UI**: sidebar entries, category tabs and tag chips use the
  short Arabic form without the parenthetical, to avoid truncation.

Thanks for the RTL support added in v2.25.2 — it made this translation
possible without needing any layout changes.

## Type of change

- [ ] `feat:` — New optimization, customize setting, or app feature
- [ ] `fix:` — Bug fix
- [ ] `refactor:` — Code restructuring without behavior change
- [x] `docs:` — Documentation
- [ ] `test:` — Adding or fixing tests
- [x] `i18n:` — Translation / localization update
- [ ] `chore:` — Build, deps, CI, tooling

## Screenshots (if UI changes)
<img width="1351" height="802" alt="{44A2659C-7E05-4C66-A4B8-B6B16CA83914}" src="https://github.com/user-attachments/assets/32d55e76-294e-48d5-86c8-2f70c2a27b04" />
<img width="1336" height="793" alt="{C35D8E5C-1467-4D7E-8F64-D044AA0414D3}" src="https://github.com/user-attachments/assets/30f61a4a-7c36-41d3-80bb-228dc79d3e31" />
<img width="1343" height="794" alt="{C81670B7-9364-4590-AE92-C8AE700B40FE}" src="https://github.com/user-attachments/assets/e60a9568-cd7c-4f06-a928-df035d79ba88" />
<img width="1337" height="788" alt="{D17960D5-37F9-4D4F-AD63-BF104F27DA19}" src="https://github.com/user-attachments/assets/9f2d5634-384c-4c56-a163-b1d5d61c61bd" />



## Notes
<img width="1337" height="788" alt="{D17960D5-37F9-4D4F-AD63-BF104F27DA19}" src="https://github.com/user-attachments/assets/c924ad5c-1395-47c4-95bc-682b8d28fee7" />


**Bidirectional text markers.** 92 entries contain LRM marks (U+200E)
wrapping Latin technical runs inside Arabic sentences — registry values
such as `DisablePowerGating=1, PP_GPUPowerDownEnabled=0`, file
extensions, and runtime placeholders followed by punctuation. Without
them, neutral characters (`=`, `,`, `.`) drift to the wrong end of the
line in an RTL context. They are invisible and affect rendering only.

**Verification:**

- `dotnet build` succeeds, 0 errors
- `dotnet test` — 198/198 passing
- `csharpier` formatted (only the file I touched)
- Key parity with `Translations.resx` verified — no missing or extra keys
- All `{0}`/`{1}` placeholders, newlines and backslashes match the source
- Reviewed every page in the running app with the UI set to Arabic

**Code change:** one line in `SettingsViewModel.cs` registering the
language. No other code touched.