### PR TITLE
i18n: Fix Korean translations

### DIFF
--- a/optimizerDuck/Resources/Languages/Translations.ko-KR.resx
+++ b/optimizerDuck/Resources/Languages/Translations.ko-KR.resx
@@ -1329,10 +1329,10 @@
     <value>새로 고침</value>
   </data>
   <data name="Common.Toggle.On" xml:space="preserve">
-    <value>~에</value>
+    <value>켜짐</value>
   </data>
   <data name="Common.Toggle.Off" xml:space="preserve">
-    <value>끄기</value>
+    <value>꺼짐</value>
   </data>
   <data name="Common.SortBy.Status" xml:space="preserve">
     <value>상태</value>


### PR DESCRIPTION
## Description

This PR updates inaccurate and awkward Korean translation strings for toggle state labels in `optimizerDuck/Resources/Languages/Translations.ko-KR.resx`.

- `Common.Toggle.On`: Changed from `~에` to `켜짐`
- `Common.Toggle.Off`: Changed from `끄기` to `꺼짐`

### Why is it needed?
- **`Common.Toggle.On` (`~에` -> `켜짐`)**: Fixes a literal mistranslation where the English preposition "on" was translated as `~에`. In UI toggle controls, `켜짐` accurately represents the active "On" state.
- **`Common.Toggle.Off` (`끄기` -> `꺼짐`)**: Changes `끄기` (an action form meaning "Turn off") to `꺼짐` (a state form meaning "Off state") to maintain grammatical and lexical consistency with `켜짐`.

Closes #

## Type of change

- [ ] `feat:` — New optimization, customize setting, or app feature
- [ ] `fix:` — Bug fix
- [ ] `refactor:` — Code restructuring without behavior change
- [ ] `docs:` — Documentation
- [ ] `test:` — Adding or fixing tests
- [x] `i18n:` — Translation / localization update
- [ ] `chore:` — Build, deps, CI, tooling

## Screenshots (if UI changes)

N/A (Text-only localization update for toggle state labels)

## Notes

- Only modified `optimizerDuck/Resources/Languages/Translations.ko-KR.resx`.
- Preserved existing XML structure and UTF-8 file encoding.
- Verified key alignment with `Translations.resx`.