### PR TITLE
docs: fix language navigation link in Indonesian README

### DIFF
--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -20,7 +20,7 @@
 
 **[Mulai Cepat](https://optimizerduck.vercel.app/docs/guides/getting-started) | [Cara Kerja](https://optimizerduck.vercel.app/docs/guides/how-it-works) | [FAQ](https://optimizerduck.vercel.app/docs/faq/general)**
 
-**English** | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md) | [Bahasa Indonesia](README.id-ID.md)
+[English](README.md) | [Tiếng Việt](README.vi.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [Русский](README.ru-RU.md) | [Français](README.fr-FR.md) | [한국어](README.ko-KR.md) | [Español](README.es-ES.md) | [日本語](README.ja-JP.md) | [Polski](README.pl-PL.md) | [Português (BR)](README.pt-BR.md) | [Türkçe](README.tr-TR.md) | [العربية](README.ar-SA.md) | **Bahasa Indonesia**
 
 <details>
 <summary>⭐ Riwayat Bintang (Star History)</summary>


### PR DESCRIPTION
## Description

What does this PR do? Why is it needed?
Fixed language navigation link in `README.id-ID.md` header so 'English' points to `README.md` and 'Bahasa Indonesia' is highlighted.

## Type of change

- [ ] `feat:` — New optimization, customize setting, or app feature
- [ ] `fix:` — Bug fix
- [ ] `refactor:` — Code restructuring without behavior change
- [x] `docs:` — Documentation
- [ ] `test:` — Adding or fixing tests
- [ ] `i18n:` — Translation / localization update
- [ ] `chore:` — Build, deps, CI, tooling

## Screenshots (if UI changes)

<!-- Drag & drop images here -->
N/A

## Notes

Any caveats, side effects, or registry paths reviewers should verify manually?
None.