### PR TITLE
feat: boot, network, DLSS, and Bing settings plus two optimizations

### DIFF
--- a/optimizerDuck/Domain/Customize/Categories/Gaming.cs
+++ b/optimizerDuck/Domain/Customize/Categories/Gaming.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using optimizerDuck.Domain.Abstractions;
 using optimizerDuck.Domain.Attributes;
+using optimizerDuck.Domain.Conditions;
 using optimizerDuck.Domain.Customize.Models;
 using optimizerDuck.Domain.Optimizations.Models.Services;
 using optimizerDuck.Domain.UI;
@@ -275,6 +276,26 @@ public class Gaming : ICustomizeCategory
                     OffValues = [1],
                     DefaultValue = 1,
                 },
+            ];
+    }
+
+    [CustomizeSetting(
+        Section = nameof(Sections.Display),
+        Icon = SymbolRegular.Eye24,
+        Recommendation = RecommendationState.Depends,
+        Condition = typeof(NvidiaGpuCondition)
+    )]
+    public class DlssIndicator : BaseCustomizeSetting
+    {
+        private const string RegPath = @"HKLM\SOFTWARE\NVIDIA Corporation\Global\NGXCore";
+
+        public override CustomizeControlType ControlType => CustomizeControlType.Dropdown;
+
+        protected override IReadOnlyList<SettingOption> GetOptions() =>
+            [
+                Option("Off", RegPath, "ShowDlssIndicator", 0),
+                Option("DebugOnly", RegPath, "ShowDlssIndicator", 1),
+                Option("AllVersions", RegPath, "ShowDlssIndicator", 1024),
             ];
     }
 }

--- a/optimizerDuck/Domain/Customize/Categories/Preferences.cs
+++ b/optimizerDuck/Domain/Customize/Categories/Preferences.cs
@@ -429,6 +429,15 @@ public class Preferences : ICustomizeCategory
             [
                 new()
                 {
+                    Path = @"HKCU\Software\Microsoft\Windows\CurrentVersion\Search",
+                    Name = "BingSearchEnabled",
+                    // null = value absent, which is Windows' default (Bing search on)
+                    OnValues = [1, null],
+                    OffValues = [0],
+                    DefaultValue = 1,
+                },
+                new()
+                {
                     Path = @"HKCU\Software\Policies\Microsoft\Windows\Explorer",
                     Name = "DisableSearchBoxSuggestions",
                     OnValues = [0],
@@ -436,6 +445,10 @@ public class Preferences : ICustomizeCategory
                     DefaultValue = 0,
                 },
             ];
+
+        // Either mechanism active means Bing search is on
+        public override Task<bool> GetStateAsync() =>
+            Task.Run(() => RegistryToggles.Any(t => t.GetState()));
     }
 
     [CustomizeSetting(

--- a/optimizerDuck/Domain/Customize/Categories/SystemFeatures.cs
+++ b/optimizerDuck/Domain/Customize/Categories/SystemFeatures.cs
@@ -18,6 +18,8 @@ public class SystemFeatures : ICustomizeCategory
         Input,
         Power,
         Developer,
+        Boot,
+        Network,
     }
 
     public string Name => Loc.Instance[$"Customize.{nameof(SystemFeatures)}.Name"];
@@ -53,6 +55,66 @@ public class SystemFeatures : ICustomizeCategory
                 },
             ];
     }
+
+    #region Boot
+
+    [CustomizeSetting(Section = nameof(Sections.Boot), Icon = SymbolRegular.Info24)]
+    public class VerboseStatus : BaseCustomizeSetting
+    {
+        protected override IEnumerable<RegistryToggle> RegistryToggles =>
+            [
+                new()
+                {
+                    Path = @"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System",
+                    Name = "VerboseStatus",
+                    OnValues = [1],
+                    OffValues = [0],
+                    DefaultValue = 0,
+                },
+            ];
+    }
+
+    [CustomizeSetting(
+        Section = nameof(Sections.Boot),
+        Icon = SymbolRegular.Clock24,
+        Recommendation = RecommendationState.Depends
+    )]
+    public class UtcHardwareClock : BaseCustomizeSetting
+    {
+        protected override IEnumerable<RegistryToggle> RegistryToggles =>
+            [
+                new()
+                {
+                    Path = @"HKLM\SYSTEM\CurrentControlSet\Control\TimeZoneInformation",
+                    Name = "RealTimeIsUniversal",
+                    OnValues = [1],
+                    OffValues = [0],
+                    DefaultValue = 0,
+                },
+            ];
+    }
+
+    #endregion
+
+    #region Network
+
+    [CustomizeSetting(Section = nameof(Sections.Network), Icon = SymbolRegular.Globe24)]
+    public class DisableSmartNameResolution : BaseCustomizeSetting
+    {
+        protected override IEnumerable<RegistryToggle> RegistryToggles =>
+            [
+                new()
+                {
+                    Path = @"HKLM\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient",
+                    Name = "DisableSmartNameResolution",
+                    OnValues = [1],
+                    OffValues = [0],
+                    DefaultValue = 0,
+                },
+            ];
+    }
+
+    #endregion
 
     #region Developer
 

--- a/optimizerDuck/Domain/Optimizations/Categories/Performance.cs
+++ b/optimizerDuck/Domain/Optimizations/Categories/Performance.cs
@@ -248,4 +248,30 @@ public class Performance : IOptimizationCategory
             return Task.FromResult(CompleteFromScope());
         }
     }
+
+    [Optimization(
+        Id = "D5A2F7C4-1E8B-4C93-B6D0-8F41AE92C7E3",
+        Risk = OptimizationRisk.Safe,
+        Tags = OptimizationTags.System | OptimizationTags.Network | OptimizationTags.Performance
+    )]
+    public class LiftWebDavFileSizeLimit : BaseOptimization
+    {
+        public override Task<ApplyResult> ApplyAsync(
+            IProgress<ProcessingProgress> progress,
+            OptimizationContext context
+        )
+        {
+            RegistryService.Write(
+                new RegistryItem(
+                    @"HKLM\SYSTEM\CurrentControlSet\Services\WebClient\Parameters",
+                    "FileSizeLimitInBytes",
+                    unchecked((int)0xFFFFFFFF),
+                    RegistryValueKind.DWord
+                )
+            );
+
+            context.Logger.LogInformation("Lifted the WebDAV file size limit to 4 GB");
+            return Task.FromResult(CompleteFromScope());
+        }
+    }
 }

--- a/optimizerDuck/Domain/Optimizations/Categories/UserExperience.cs
+++ b/optimizerDuck/Domain/Optimizations/Categories/UserExperience.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
 using optimizerDuck.Domain.Abstractions;
 using optimizerDuck.Domain.Attributes;
 using optimizerDuck.Domain.Conditions;
@@ -149,6 +150,33 @@ public class UserExperience : IOptimizationCategory
                 )
             );
             context.Logger.LogInformation("Disabled Microsoft 365 ads in Settings");
+            return Task.FromResult(CompleteFromScope());
+        }
+    }
+
+    [Optimization(
+        Id = "3F8B91D2-6A47-4E05-9C2B-E70D14F8A5C6",
+        Risk = OptimizationRisk.Safe,
+        Tags = OptimizationTags.System | OptimizationTags.Network
+    )]
+    public sealed class MaximizeUpdatePauseLimit : BaseOptimization
+    {
+        public override Task<ApplyResult> ApplyAsync(
+            IProgress<ProcessingProgress> progress,
+            OptimizationContext context
+        )
+        {
+            // DWORD maximum; only honored by Windows versions that still support this setting
+            RegistryService.Write(
+                new RegistryItem(
+                    @"HKLM\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings",
+                    "FlightSettingsMaxPauseDays",
+                    unchecked((int)0xFFFFFFFF),
+                    RegistryValueKind.DWord
+                )
+            );
+
+            context.Logger.LogInformation("Maximized the Windows Update pause limit");
             return Task.FromResult(CompleteFromScope());
         }
     }

--- a/optimizerDuck/Resources/Languages/Translations.resx
+++ b/optimizerDuck/Resources/Languages/Translations.resx
@@ -638,6 +638,12 @@
   <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
     <value>Configures the Multimedia Class Scheduler Service (MMCSS) for gaming and low latency by prioritizing multimedia workloads and disabling network throttling.</value>
   </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.Name" xml:space="preserve">
+    <value>Lift WebDAV 50 MB limit</value>
+  </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.ShortDescription" xml:space="preserve">
+    <value>Raises the WebClient file size limit for WebDAV mounts from 50 MB to 4 GB so large files stop failing on network locations.</value>
+  </data>
   <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
     <value>Optimize Keyboard Repeat</value>
   </data>
@@ -791,6 +797,12 @@
   </data>
   <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
     <value>Sets StartupDelayInMSec=0, MenuShowDelay=0 to eliminate Explorer startup delay and reduce menu hover delay to minimum.</value>
+  </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.Name" xml:space="preserve">
+    <value>Maximize update pause limit</value>
+  </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.ShortDescription" xml:space="preserve">
+    <value>Sets the Windows Update pause ceiling to the largest supported value. Only honored by Windows versions that still support this setting; security updates stay paused while it is active.</value>
   </data>
   <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.Name" xml:space="preserve">
     <value>Disable Start Menu Web Search</value>
@@ -1056,6 +1068,24 @@
   </data>
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
     <value>GPU scheduling offloads frame management from the CPU to the GPU, cutting display latency and improving frame pacing.</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Name" xml:space="preserve">
+    <value>DLSS overlay indicator</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Description" xml:space="preserve">
+    <value>Controls the on-screen DLSS indicator overlay used to verify which DLSS version a game actually renders with.</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Recommendation.Reason" xml:space="preserve">
+    <value>A diagnostic overlay; leave off unless you are checking DLSS behavior.</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.DebugOnly" xml:space="preserve">
+    <value>Debug DLLs only</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.AllVersions" xml:space="preserve">
+    <value>All DLSS versions</value>
   </data>
   <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
     <value>Do NOT change unless you know exactly what you are doing</value>
@@ -1683,6 +1713,12 @@ Update now to enjoy the latest features, improvements, and bug fixes.</value>
   <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
     <value>Input Settings</value>
   </data>
+  <data name="Customize.SystemFeatures.Section.Boot" xml:space="preserve">
+    <value>Boot Settings</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Network" xml:space="preserve">
+    <value>Network Settings</value>
+  </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
     <value>NumLock on Boot</value>
   </data>
@@ -1691,6 +1727,27 @@ Update now to enjoy the latest features, improvements, and bug fixes.</value>
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
     <value>Enabling NumLock at boot ensures the numpad is ready immediately after login, avoiding manual toggling each time.</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Name" xml:space="preserve">
+    <value>Verbose status messages</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Description" xml:space="preserve">
+    <value>Show the exact service, driver, or step being processed during startup, shutdown, and updates instead of a generic spinner.</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Name" xml:space="preserve">
+    <value>Hardware clock uses UTC</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Description" xml:space="preserve">
+    <value>Interpret the hardware clock as UTC. Required on Windows/Linux dual-boot so both systems agree on the clock; on single-boot machines the time jumps by your timezone offset until this is turned back off.</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Recommendation.Reason" xml:space="preserve">
+    <value>Enable only when another OS on this machine also treats the hardware clock as UTC.</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Name" xml:space="preserve">
+    <value>DNS leak protection</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Description" xml:space="preserve">
+    <value>Disables Smart Multi-Homed Name Resolution so DNS queries stop racing out of every network adapter at once. Prevents queries from bypassing the tunnel when a VPN is in use.</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
     <value>Power Settings</value>

--- a/optimizerDuck/Resources/Languages/Translations.zh-CN.resx
+++ b/optimizerDuck/Resources/Languages/Translations.zh-CN.resx
@@ -580,6 +580,12 @@
   <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
     <value>配置多媒体类调度服务 (MMCSS) 以优化游戏和低延迟，通过优先处理多媒体工作负载和禁用网络节流。</value>
   </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.Name" xml:space="preserve">
+    <value>解除 WebDAV 50MB 限制</value>
+  </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.ShortDescription" xml:space="preserve">
+    <value>把 WebClient 对 WebDAV 挂载的文件大小限制从 50MB 抬到 4GB，网络位置上的大文件不再传输失败。</value>
+  </data>
   <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
     <value>优化键盘响应速度</value>
   </data>
@@ -721,6 +727,12 @@
   </data>
   <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
     <value>将 StartupDelayInMSec 和 MenuShowDelay 均设为 0，以消除资源管理器启动延迟，并将菜单悬停延迟降至最低。</value>
+  </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.Name" xml:space="preserve">
+    <value>更新暂停上限拉满</value>
+  </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.ShortDescription" xml:space="preserve">
+    <value>把 Windows 更新的可暂停天数抬到支持的最大值。仅在仍支持该设置的旧版 Windows 上生效，生效期间安全更新同样暂停。</value>
   </data>
   <data name="Optimizer.UserExperience.DisableStartMenuWebSearch.Name" xml:space="preserve">
     <value>禁用开始菜单网络搜索</value>
@@ -986,6 +998,24 @@
   </data>
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Recommendation.Reason" xml:space="preserve">
     <value>GPU 调度将帧管理从 CPU 转移到 GPU，降低显示延迟，优化帧率稳定性。</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Name" xml:space="preserve">
+    <value>DLSS 指示器叠加层</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Description" xml:space="preserve">
+    <value>控制屏幕上的 DLSS 指示器叠加层，用于确认游戏实际渲染使用的 DLSS 版本。</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Recommendation.Reason" xml:space="preserve">
+    <value>诊断用叠加层，不查 DLSS 行为时保持关闭即可。</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.Off" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.DebugOnly" xml:space="preserve">
+    <value>仅调试版 DLL</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.AllVersions" xml:space="preserve">
+    <value>所有 DLSS 版本</value>
   </data>
   <data name="Settings.Optimize.ShellTimeout.Warning" xml:space="preserve">
     <value>若非完全了解用途，请勿修改此项</value>
@@ -1613,6 +1643,12 @@
   <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
     <value>输入设置</value>
   </data>
+  <data name="Customize.SystemFeatures.Section.Boot" xml:space="preserve">
+    <value>启动设置</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Network" xml:space="preserve">
+    <value>网络设置</value>
+  </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
     <value>开机启用数字小键盘</value>
   </data>
@@ -1621,6 +1657,27 @@
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Recommendation.Reason" xml:space="preserve">
     <value>开机启用数字小键盘，登录后即可直接使用，无需每次手动开启。</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Name" xml:space="preserve">
+    <value>详细启动状态</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Description" xml:space="preserve">
+    <value>开机、关机、更新时显示正在处理的具体服务、驱动和步骤，而不是笼统的转圈提示。</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Name" xml:space="preserve">
+    <value>硬件时钟使用 UTC</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Description" xml:space="preserve">
+    <value>把硬件时钟按 UTC 解释。Windows/Linux 双系统必须开启，否则两边时间互相打架；单系统开启后时间会偏差一个时区，需要再关掉。</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Recommendation.Reason" xml:space="preserve">
+    <value>只在机器上还有另一个把硬件时钟当 UTC 的系统时开启。</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Name" xml:space="preserve">
+    <value>DNS 防泄露</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Description" xml:space="preserve">
+    <value>关闭智能多宿主名称解析，DNS 查询不再同时从所有网卡抢发。使用 VPN 时可防止查询绕过隧道造成 DNS 泄露。</value>
   </data>
   <data name="Customize.SystemFeatures.Section.Power" xml:space="preserve">
     <value>电源设置</value>

--- a/optimizerDuck/Resources/Languages/Translations.zh-TW.resx
+++ b/optimizerDuck/Resources/Languages/Translations.zh-TW.resx
@@ -534,6 +534,12 @@
   <data name="Optimizer.Performance.OptimizeMultimediaScheduler.ShortDescription" xml:space="preserve">
     <value>設定多媒體類別排程器服務 (MMCSS) 以優化遊戲和低延遲，透過優先處理多媒體工作負載和停用網路節流。</value>
   </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.Name" xml:space="preserve">
+    <value>解除 WebDAV 50MB 限制</value>
+  </data>
+  <data name="Optimizer.Performance.LiftWebDavFileSizeLimit.ShortDescription" xml:space="preserve">
+    <value>把 WebClient 對 WebDAV 掛載的檔案大小限制從 50MB 抬到 4GB，網路位置上的大檔案不再傳輸失敗。</value>
+  </data>
   <data name="Optimizer.Performance.KeyboardLatencyOptimization.Name" xml:space="preserve">
     <value>最佳化鍵盤反應</value>
   </data>
@@ -1302,6 +1308,12 @@
   <data name="Optimizer.UserExperience.SpeedUpExplorerAndMenus.ShortDescription" xml:space="preserve">
     <value>將 StartupDelayInMSec 與 MenuShowDelay 設為 0，以消除檔案總管啟動延遲並將選單懸停延遲降至最低。</value>
   </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.Name" xml:space="preserve">
+    <value>更新暫停上限拉滿</value>
+  </data>
+  <data name="Optimizer.UserExperience.MaximizeUpdatePauseLimit.ShortDescription" xml:space="preserve">
+    <value>把 Windows 更新的可暫停天數抬到支援的最大值。僅在仍支援此設定的舊版 Windows 上生效，生效期間安全性更新同樣暫停。</value>
+  </data>
   <data name="Optimizer.UserExperience.DisableVisualEffects.Name" xml:space="preserve">
     <value>停用視覺效果</value>
   </data>
@@ -1464,6 +1476,24 @@
   <data name="Customize.Gaming.HardwareAcceleratedGpuScheduling.Description" xml:space="preserve">
     <value>讓 GPU 處理更多視訊記憶體排程工作，需要相容的顯示卡驅動程式。</value>
   </data>
+  <data name="Customize.Gaming.DlssIndicator.Name" xml:space="preserve">
+    <value>DLSS 指示器疊加層</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Description" xml:space="preserve">
+    <value>控制螢幕上的 DLSS 指示器疊加層，用於確認遊戲實際渲染使用的 DLSS 版本。</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Recommendation.Reason" xml:space="preserve">
+    <value>診斷用疊加層，不查 DLSS 行為時保持關閉即可。</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.Off" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.DebugOnly" xml:space="preserve">
+    <value>僅偵錯版 DLL</value>
+  </data>
+  <data name="Customize.Gaming.DlssIndicator.Options.AllVersions" xml:space="preserve">
+    <value>所有 DLSS 版本</value>
+  </data>
   <data name="Common.OpenFolder" xml:space="preserve">
     <value>開啟資料夾</value>
   </data>
@@ -1485,11 +1515,38 @@
   <data name="Customize.SystemFeatures.Section.Input" xml:space="preserve">
     <value>輸入設定</value>
   </data>
+  <data name="Customize.SystemFeatures.Section.Boot" xml:space="preserve">
+    <value>開機設定</value>
+  </data>
+  <data name="Customize.SystemFeatures.Section.Network" xml:space="preserve">
+    <value>網路設定</value>
+  </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Name" xml:space="preserve">
     <value>開機時的 NumLock</value>
   </data>
   <data name="Customize.SystemFeatures.NumLockOnBoot.Description" xml:space="preserve">
     <value>設定進入 Windows 登入畫面時是否開啟 Num Lock。</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Name" xml:space="preserve">
+    <value>詳細開機狀態</value>
+  </data>
+  <data name="Customize.SystemFeatures.VerboseStatus.Description" xml:space="preserve">
+    <value>開機、關機、更新時顯示正在處理的具體服務、驅動程式和步驟，而不是籠統的轉圈提示。</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Name" xml:space="preserve">
+    <value>硬體時鐘使用 UTC</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Description" xml:space="preserve">
+    <value>把硬體時鐘按 UTC 解釋。Windows/Linux 雙系統必須開啟，否則兩邊時間互相打架；單系統開啟後時間會偏差一個時區，需要再關掉。</value>
+  </data>
+  <data name="Customize.SystemFeatures.UtcHardwareClock.Recommendation.Reason" xml:space="preserve">
+    <value>只在機器上還有另一個把硬體時鐘當 UTC 的系統時開啟。</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Name" xml:space="preserve">
+    <value>DNS 防洩漏</value>
+  </data>
+  <data name="Customize.SystemFeatures.DisableSmartNameResolution.Description" xml:space="preserve">
+    <value>關閉智慧多宿主名稱解析，DNS 查詢不再同時從所有網卡搶發。使用 VPN 時可防止查詢繞過通道造成 DNS 洩漏。</value>
   </data>
   <data name="Customize.Desktop.Name" xml:space="preserve">
     <value>桌面</value>


### PR DESCRIPTION
## Summary

Customize settings:
- **Verbose status messages** (SystemFeatures → new Boot section): show the exact service/driver/step during startup, shutdown, and updates instead of a generic spinner
- **Hardware clock uses UTC** (Boot): for Windows/Linux dual-boot; time jumps by timezone offset on single-boot machines until turned off
- **DNS leak protection** (new Network section): disables Smart Multi-Homed Name Resolution so DNS queries stop racing out of every adapter — relevant with a VPN
- **DLSS overlay indicator** (Gaming → Display): three-state dropdown (off / debug DLLs only / all DLSS versions), gated to NVIDIA GPUs via the existing GPU condition
- **Bing search** toggle reworked: now writes `BingSearchEnabled` alongside the existing `DisableSearchBoxSuggestions` policy; state shows on when **either** mechanism is active (the old setting only touched the policy key, and its name oversold what it did)

Optimizations (quantity-type values fit the one-shot + revert model better than a live toggle):
- **Lift WebDAV 50 MB limit** (Performance): `FileSizeLimitInBytes` to DWORD max (4 GB)
- **Maximize update pause limit** (UserExperience): `FlightSettingsMaxPauseDays` to DWORD max — only honored by Windows versions that still support the setting

Strings added to en / zh-CN / zh-TW; other locales fall back to English until translated.

## Test plan

- [x] `dotnet build` — 0 warnings / 0 errors
- [x] `dotnet test` — 274/274 pass
- [x] Manually verified on Win11: toggles write/read both keys (Bing OR-state), dropdown round-trips, optimizations apply and revert